### PR TITLE
Add button theme

### DIFF
--- a/src/styles/button.tsx
+++ b/src/styles/button.tsx
@@ -1,0 +1,30 @@
+export const Button = {
+  baseStyle: {
+    border: '2px solid',
+    fontSize: 'md',
+    fontWeight: 'bold',
+    px: 6,
+    py: 4,
+  },
+  // TODO: update variants with correct imported colors
+  variants: {
+    gray: {
+      backgroundColor: 'rgba(128, 128, 128, 0.2)',
+      borderColor: 'gray',
+      color: 'gray',
+    },
+    green: {
+      backgroundColor: 'rgba(0, 128, 0, 0.2)',
+      borderColor: 'green',
+      color: 'green',
+    },
+    purple: {
+      backgroundColor: 'rgba(128, 0, 128, 0.2)',
+      borderColor: 'purple.500',
+      color: 'purple.500',
+    },
+  },
+  defaultProps: {
+    variant: 'green',
+  },
+}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,10 +1,16 @@
 import { extendTheme, ThemeConfig } from '@chakra-ui/react'
 
+import { Button } from 'styles/button'
+
 const config: ThemeConfig = {
   initialColorMode: 'dark',
   useSystemColorMode: false,
 }
 
-const theme = extendTheme({ config })
+const components = {
+  Button,
+}
+
+const theme = extendTheme({ config, components })
 
 export default theme


### PR DESCRIPTION
## Description
Adds simple button theme for most used button component throughout the app. There are 3 variants named by colors:
* green (default)
* gray
* purple

Once the real colors are added to the project, they should be updated in `button.tsx` (added a `TODO`).

##  Testing
Test by adding to any page:
```typescript
import { Button } from '@chakra-ui/react'

...

    <ProductPage tokenData={DefiPulseIndex} marketData={dpi || {}}>
      <div>
        ...
        <Button>Claim Rewards</Button>
        <Button variant='gray'>Claim Rewards</Button>
        <Button variant='purple'>Claim Rewards</Button>
      </div>
    </ProductPage>
```

