### PR TITLE
Add calculating others position for pie chart

### DIFF
--- a/src/components/views/DashboardData.ts
+++ b/src/components/views/DashboardData.ts
@@ -73,6 +73,37 @@ function getPosition(
   }
 }
 
+function getOthersPosition(
+  remainingPositions: Position[],
+  totalBalance: BigNumber
+) {
+  let othersPosition: Position | null = null
+
+  if (remainingPositions.length < 1) {
+    return othersPosition
+  }
+
+  const lastColor = chartColors.slice(-1)[0]
+  if (remainingPositions.length === 1) {
+    othersPosition = remainingPositions[0]
+    othersPosition.backgroundColor = lastColor
+  } else {
+    const initialVal = BigNumber.from(0)
+    const sumOthers = remainingPositions.reduce(
+      (prevValue, pos) => prevValue.add(BigNumber.from(pos.value)),
+      initialVal
+    )
+    othersPosition = getPosition(
+      'OTHERS',
+      BigNumber.from(sumOthers),
+      totalBalance,
+      lastColor
+    )
+  }
+
+  return othersPosition
+}
+
 // Gets 4 top positions and reduces rest to others
 export function getPieChartPositions(
   balances: {
@@ -118,12 +149,10 @@ export function getPieChartPositions(
     return positionWithColor
   })
 
-  // TODO: take all other balances and reduce to 'Others' position
-  const othersPosition = getPosition(
-    'OTHERS',
-    BigNumber.from(100),
-    totalBalance,
-    chartColors.slice(-1)[0]
+  const remainingPositions = sortedPositions.slice(4)
+  let othersPosition: Position | null = getOthersPosition(
+    remainingPositions,
+    totalBalance
   )
 
   const pieChartPositions = [...top4PositionsWithColors]


### PR DESCRIPTION
## **Type of Change**

###### _Select a category that relates to the content of your pull request (choose all that apply)._

- [ ] Bug Fix
- [ ] Content
- [x] New Feature
- [ ] Documentation
- [ ] Code Refactoring

&nbsp;

## **Summary of Changes**

As the title implies adds the missing logic for showing the others position in the pie chart (dashboard).

* If there is only 5 positions (or less) in general, those will be shown individually
* More than 5 position, top 4 will be shown and rest will be reduced to `Others`

&nbsp;

## **Submission Reminders**

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `SetProtocol/index-ui`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
