### PR TITLE
Make products table responsive

### DIFF
--- a/src/components/products/ProductsTable.tsx
+++ b/src/components/products/ProductsTable.tsx
@@ -1,6 +1,14 @@
 import { useICColorMode } from 'styles/colors'
 
-import { Table, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/react'
+import {
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  useBreakpointValue,
+} from '@chakra-ui/react'
 
 import PerformanceCell from 'components/products/PerformanceCell'
 import TickerCell from 'components/products/TickerCell'
@@ -15,25 +23,35 @@ type ProductsTableProps = {
 
 const ProductsTable = ({ products }: ProductsTableProps) => {
   const { isDarkMode } = useICColorMode()
+  const isMobile = useBreakpointValue({ base: true, md: false, lg: false })
+
   const colorScheme = isDarkMode ? 'whiteAlpha' : 'blackAlpha'
+  const amountOfIntervalsToShow = isMobile ? 2 : PriceChangeIntervals.length
+  const priceChangeIntervals = PriceChangeIntervals.slice(
+    0,
+    amountOfIntervalsToShow
+  )
+
   return (
     <Table colorScheme={colorScheme}>
       <Thead>
         <Tr>
-          <Th>Ticker</Th>
-          {PriceChangeIntervals.map((interval) => (
-            <Th key={interval[0]}>{interval[0]}</Th>
+          <Th p={['8px 8px', '12px 24px']}>Ticker</Th>
+          {priceChangeIntervals.map((interval) => (
+            <Th key={interval[0]} p={['8px 8px', '12px 24px']}>
+              {interval[0]}
+            </Th>
           ))}
         </Tr>
       </Thead>
       <Tbody>
         {products.map((product) => (
           <Tr key={product.symbol}>
-            <Td>
+            <Td p={['16px 8px', '16px 24px']}>
               <TickerCell product={product} />
             </Td>
-            {PriceChangeIntervals.map((interval) => (
-              <Td key={interval[0]}>
+            {priceChangeIntervals.map((interval) => (
+              <Td key={interval[0]} p={['16px 8px', '16px 24px']}>
                 <PerformanceCell
                   percentChange={product.performance?.[interval[0]]}
                 />

--- a/src/components/products/TickerCell.tsx
+++ b/src/components/products/TickerCell.tsx
@@ -1,4 +1,11 @@
-import { Grid, GridItem, Image, Link, Text } from '@chakra-ui/react'
+import {
+  Grid,
+  GridItem,
+  Image,
+  Link,
+  Text,
+  useBreakpointValue,
+} from '@chakra-ui/react'
 
 import { ProductsTableProduct } from 'components/views/Products'
 
@@ -7,27 +14,41 @@ type TickerCellProps = {
 }
 
 const TickerCell = ({ product }: TickerCellProps) => {
+  const isWeb = useBreakpointValue({
+    base: false,
+    md: true,
+    lg: true,
+    xl: true,
+  })
+
   return (
     <Link href={'/products/' + product.url}>
       <Grid
-        width='320px'
-        templateRows='repeat(2, 1fr)'
-        templateColumns='70px auto'
+        width={['inherit', 'inherit', '320px']}
+        templateRows={['', '', 'repeat(2, 1fr)']}
+        templateColumns={['32px auto', '32px auto', '70px auto']}
       >
         <GridItem colStart={1} rowSpan={2}>
           <Image
             src={product.image}
             fallbackSrc='https://app.indexcoop.com/static/media/index-token.c853e1be.png'
-            boxSize={50}
+            h={[25, 25, 50, 50]}
           />
         </GridItem>
+        {isWeb && (
+          <GridItem colStart={2}>
+            <Text fontSize='sm' variant='secondary' align='left'>
+              {product.name}
+            </Text>
+          </GridItem>
+        )}
         <GridItem colStart={2}>
-          <Text fontSize='sm' variant='secondary' align='left'>
-            {product.name}
+          <Text
+            fontSize={['sm', 'sm', 'xl']}
+            fontWeight={['600', '600', '500']}
+          >
+            {product.symbol}
           </Text>
-        </GridItem>
-        <GridItem colStart={2}>
-          <Text fontSize='xl'>{product.symbol}</Text>
         </GridItem>
       </Grid>
     </Link>


### PR DESCRIPTION
## **Summary of Changes**

Makes products table under `/products` responsive. There is no way to keep all the info for small resolutions, so decided to only show `1D` and `1W`.

&nbsp;

## **Test Data or Screenshots**

![localhost_3000_products(iPhone SE)](https://user-images.githubusercontent.com/2104965/156147655-97942f3c-a787-4fd2-a319-89367c248917.png)

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
