### PR TITLE
Fix current supply 

### DIFF
--- a/src/components/product/ProductPage.tsx
+++ b/src/components/product/ProductPage.tsx
@@ -12,6 +12,7 @@ import {
   useMarketData,
 } from 'providers/MarketData/MarketDataProvider'
 import { SetComponent } from 'providers/SetComponents/SetComponentsProvider'
+import { displayFromWei } from 'utils'
 import {
   getFormattedChartPriceChanges,
   getPricesChanges,
@@ -39,7 +40,7 @@ function getStatsForToken(
     notation: 'compact',
   })
 
-  let supplyFormatter = Intl.NumberFormat('en')
+  let supplyFormatter = Intl.NumberFormat('en', { maximumFractionDigits: 2 })
 
   const marketCap =
     marketData.marketcaps
@@ -90,14 +91,24 @@ const ProductPage = (props: {
     }
 
     const fetchSupply = async () => {
-      const setDetails = await getTokenSupply(library, [tokenAddress], chainId)
-      const e18 = BigNumber.from('1000000000000000000')
-      const supply = setDetails[0].totalSupply.div(e18).toNumber()
-      setCurrentTokenSupply(supply)
+      try {
+        const setDetails = await getTokenSupply(
+          library,
+          [tokenAddress],
+          chainId
+        )
+        if (setDetails.length < 1) return
+        const supply = parseFloat(
+          displayFromWei(setDetails[0].totalSupply) ?? '0'
+        )
+        setCurrentTokenSupply(supply)
+      } catch (error) {
+        console.log(error)
+      }
     }
 
     fetchSupply()
-  }, [tokenData])
+  }, [chainId, library, tokenData])
 
   const priceChartData = getPriceChartData([marketData])
 


### PR DESCRIPTION
## **Summary of Changes**

Fixes the current supply for token stats on product page as noted by @TheodoreChuang wasn't working correctly.

&nbsp;

## **Test Data or Screenshots**

`getTokenSupply` sometimes returns the following error. Could not figure out what's the issue though. Thoughts?

```
Error: unknown account #0 (operation="getAddress", code=UNSUPPORTED_OPERATION, version=providers/5.5.0)
    at Logger.makeError (index.ts:225:1)
    at Logger.throwError (index.ts:237:1)
    at json-rpc-provider.ts:161:1
```
&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
