### PR TITLE
fix: LP mining not longer shows APY if not active

### DIFF
--- a/src/components/mining/MiningProgram.tsx
+++ b/src/components/mining/MiningProgram.tsx
@@ -106,7 +106,7 @@ const MiningProgram = (props: { program: Program }) => {
     staked.value = displayFromWei(balances[staked.stakedBalanceKey], 5) ?? '0.0'
   }
 
-  apy.value = `${stakingApy ?? '0.0'}%`
+  apy.value = `${(isPoolActive && stakingApy) || '0.0'}%`
 
   if (unclaimed.unclaimedBalanceKey) {
     unclaimed.value =


### PR DESCRIPTION
## **Summary of Changes**

GMI is displaying an APY of ~132.0% on the Liquidity Mining page even though the program is no longer active. Fixed the rendering logic to correctly display 0.0%

&nbsp;

## **Test Data or Screenshots**

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
