### PR TITLE
fix: add missing tokenContextKey

### DIFF
--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -264,6 +264,7 @@ export const Matic2xFLIP: Token = {
   image: maticflipLogo,
   coingeckoId: 'index-coop-matic-2x-flexible-leverage-index',
   tokensetsId: 'matic2x-fli-p',
+  tokenContextKey: 'maticflip',
   fees: {
     streamingFee: '1.95%',
     mintRedeemFee: '0.1%',
@@ -281,6 +282,7 @@ export const IMaticFLIP: Token = {
   image: imaticflipLogo,
   coingeckoId: 'index-coop-inverse-matic-flexible-leverage-index',
   tokensetsId: 'imatic-fli-p',
+  tokenContextKey: 'imaticflip',
   fees: {
     streamingFee: '1.95%',
     mintRedeemFee: '0.1%',
@@ -298,6 +300,7 @@ export const IEthereumFLIP: Token = {
   image: iethflipLogo,
   coingeckoId: 'index-coop-inverse-eth-flexible-leverage-index',
   tokensetsId: 'ieth-fli-p',
+  tokenContextKey: 'iethflip',
   fees: {
     streamingFee: '1.95%',
     mintRedeemFee: '0.1%',
@@ -315,6 +318,7 @@ export const Bitcoin2xFLIP: Token = {
   image: btcflipLogo,
   coingeckoId: 'btc-2x-flexible-leverage-index-polygon',
   tokensetsId: 'btc2x-fli-p',
+  tokenContextKey: 'btcflip',
   fees: {
     streamingFee: '1.95%',
     mintRedeemFee: '0.1%',
@@ -332,6 +336,7 @@ export const IBitcoinFLIP: Token = {
   image: ibtcflipLogo,
   coingeckoId: 'inverse-btc-flexible-leverage-index',
   tokensetsId: 'ibtc-fli-p',
+  tokenContextKey: 'ibtcflip',
   fees: {
     streamingFee: '1.95%',
     mintRedeemFee: '0.1%',
@@ -349,6 +354,7 @@ export const icETHIndex: Token = {
   image: icethLogo,
   coingeckoId: 'interest-compounding-eth-index',
   tokensetsId: 'iceth',
+  tokenContextKey: 'iceth',
   fees: {
     streamingFee: '0.9%',
     mintRedeemFee: '0.35%',


### PR DESCRIPTION
## **Summary of Changes**
Add missing `tokenContextKey` in our Tokens constants. This key is used on the `/products` page and without them the app is currently rendering no market data for these tokens.
&nbsp;

## **Test Data or Screenshots**

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
