### PR TITLE
fix: nav underline color on hover for light mode

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -9,6 +9,7 @@ import {
   IconButton,
   Link,
   Text,
+  useBreakpointValue,
   useColorMode,
   useColorModeValue,
 } from '@chakra-ui/react'
@@ -62,7 +63,7 @@ const NavLink = (props: {
 
 const NavContent = () => {
   const { colorMode, toggleColorMode } = useColorMode()
-  const textColor = colorMode === 'light' ? 'black' : 'white'
+  const textColor = colorMode === 'light' ? colors.black : colors.icWhite
   return (
     <Flex
       flexDirection={['column', 'column', 'column', 'row']}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -76,12 +76,12 @@ const initSentryEventTracking = () => {
   const ENVIRONMENTS = {
     development: 'index-app-development',
     production: 'index-app-prod',
-    staging: 'index-app-staging'
+    staging: 'index-app-staging',
   }
   const isStaging = process.env.REACT_APP_SENTRY_ENV
   const isDevelopment = process.env.NODE_ENV === 'development'
   const isProduction = process.env.NODE_ENV === 'production'
-  
+
   let environment = 'undefined'
   if (isStaging) {
     environment = ENVIRONMENTS.staging
@@ -90,7 +90,7 @@ const initSentryEventTracking = () => {
   } else if (isProduction) {
     environment = ENVIRONMENTS.production
   }
-    
+
   Sentry.init({
     environment,
     dsn: 'https://a1f6cd2b7ce842b2a471a6c49def712e@o1145781.ingest.sentry.io/6213525',
@@ -100,7 +100,7 @@ const initSentryEventTracking = () => {
     // of transactions for performance monitoring.
     // We recommend adjusting this value in production
     tracesSampleRate: 1.0,
-  })  
+  })
 }
 initSentryEventTracking()
 


### PR DESCRIPTION
## **Summary of Changes**

Fix the underline colour when hovering on navigation items during light mode. Dark mode is fine so no changes are required.

### Current
There is a white under line during light mode.
Mobile Menu:
<img width="137" alt="Screen Shot 2022-03-26 at 11 03 12 PM" src="https://user-images.githubusercontent.com/13758946/160238598-9de9ccbb-b7e9-46af-a255-35e1d81734ec.png">

Desktop Menu has a white line on white background so it is not visible

### Fix
Correct the underline colour from white to black during light mode.
Mobile View:
<img width="143" alt="Screen Shot 2022-03-26 at 11 03 25 PM" src="https://user-images.githubusercontent.com/13758946/160238687-9aabbd85-882e-4c7b-b9a9-17b6a7e3d3ec.png">

Desktop View:

<img width="114" alt="Screen Shot 2022-03-26 at 11 03 36 PM" src="https://user-images.githubusercontent.com/13758946/160238700-81082021-261f-42af-ab5a-8b5d3b82b2c4.png">

&nbsp;

## **Test Data or Screenshots**

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
