### PR TITLE
fix: update Quick Trade To with buy amount instead of price(rate)

### DIFF
--- a/src/components/dashboard/QuickTrade.tsx
+++ b/src/components/dashboard/QuickTrade.tsx
@@ -591,6 +591,13 @@ function getTradeInfoData0x(
   if (gasPrice === undefined || gas === undefined || sources === undefined)
     return []
 
+  const buyAmount =
+    displayFromWei(
+      BigNumber.from(zeroExTradeData.buyAmount),
+      undefined,
+      tokenDecimals
+    ) ?? '0.0'
+
   const minReceive =
     displayFromWei(zeroExTradeData.minOutput, undefined, tokenDecimals) ?? '0.0'
 
@@ -603,7 +610,7 @@ function getTradeInfoData0x(
     .map((source) => source.name)
 
   return [
-    { title: 'Price', value: zeroExTradeData.price },
+    { title: 'Buy Amount', value: buyAmount },
     { title: 'Minimum Receive', value: minReceive },
     { title: 'Network Fee', value: `${networkFee} ${networkToken}` },
     { title: 'Offered From', value: offeredFromSources.toString() },

--- a/src/components/dashboard/TradeInfo.tsx
+++ b/src/components/dashboard/TradeInfo.tsx
@@ -5,8 +5,8 @@ export interface TradeInfoItem {
   value: string
 }
 
-const excludePriceItem = (tradeInfoItem: TradeInfoItem): boolean =>
-  tradeInfoItem.title !== 'Price'
+const excludeBuyAmountItem = (tradeInfoItem: TradeInfoItem): boolean =>
+  tradeInfoItem.title !== 'Buy Amount'
 
 const TradeInfoItemRow = (props: { title: string; value: string }) => {
   const parsedValue = parseFloat(props.value)
@@ -26,7 +26,7 @@ const TradeInfoItemRow = (props: { title: string; value: string }) => {
 const TradeInfo = (props: { data: TradeInfoItem[] }) => {
   return (
     <Flex direction='column'>
-      {props.data.filter(excludePriceItem).map((item, index) => (
+      {props.data.filter(excludeBuyAmountItem).map((item, index) => (
         <Box key={index} mb='16px'>
           <TradeInfoItemRow title={item.title} value={item.value} />
         </Box>


### PR DESCRIPTION
## **Summary of Changes**

Fix for merged PR https://github.com/IndexCoop/index-app/pull/147

Issue: `To` displays the price/rate instead of estimated amount of tokens to be purchased

Fix: change the data point to pull amount instead of rate

&nbsp;

## **Test Data or Screenshots**

&nbsp;

Currently 2 ETH would incorrectly show ~15.221 DPI
<img width="1353" alt="Screen Shot 2022-03-31 at 11 41 09 PM" src="https://user-images.githubusercontent.com/13758946/161057317-cde83a58-5f22-439e-aa4c-20ebc0dc0f09.png">

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
