### PR TITLE
fix: Quick Trade maintains token pair when flipping

### DIFF
--- a/src/components/dashboard/QuickTrade.tsx
+++ b/src/components/dashboard/QuickTrade.tsx
@@ -218,16 +218,16 @@ const QuickTrade = (props: {
   }, [chainId])
 
   useEffect(() => {
+    const prevSellToken = sellToken
+    const prevBuyToken = buyToken
     const currencyTokensList = getCurrencyTokensByChain()
     const tokenList = getTokenListByChain()
     const sellTokenList = isBuying ? currencyTokensList : tokenList
     const buyTokenList = isBuying ? tokenList : currencyTokensList
-    const sellToken = sellTokenList[0]
-    const buyToken = buyTokenList[0]
     setSellTokenList(sellTokenList)
     setBuyTokenList(buyTokenList)
-    setSellToken(sellToken)
-    setBuyToken(buyToken)
+    setSellToken(prevBuyToken)
+    setBuyToken(prevSellToken)
   }, [isBuying])
 
   useEffect(() => {


### PR DESCRIPTION
## **Summary of Changes**

### BUG:
The Quick Trade flip icon <> resets the token pairs (ETH+DPI | MATIC+DPI) when clicked instead of maintaining the select token pairs and flipping.

&nbsp;

## **Test Data or Screenshots**

Testing various combinations including:
- flipping default pairs (ex. ETH+DPI)
- changing one token and flipping (ex. ETH+DPI -> ETH+BED <> BED+ETH)
- changing both tokens and flipping (ex. ETH+DPI -> DAI+MVI <> MVI+DAI)
- same behaviour for either chain

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
