### PR TITLE
show estimated gas for Lev EI

### DIFF
--- a/src/components/dashboard/QuickTrade.tsx
+++ b/src/components/dashboard/QuickTrade.tsx
@@ -179,6 +179,7 @@ const QuickTrade = (props: {
       : getTradeInfoDataFromEI(
           bestOptionResult.leveragedExchangeIssuanceData?.setTokenAmount ??
             BigNumber.from(0),
+          bestOptionResult.leveragedExchangeIssuanceData?.gasPrice ?? BigNumber.from(0),
           bestOptionResult.leveragedExchangeIssuanceData,
           isBuying ? buyToken.decimals : sellToken.decimals,
           chainId
@@ -548,6 +549,7 @@ const TradeButton = (props: TradeButtonProps) => (
 
 function getTradeInfoDataFromEI(
   setAmount: BigNumber,
+  gasPrice: BigNumber,
   data:
     | ExchangeIssuanceQuote
     | LeveragedExchangeIssuanceQuote
@@ -560,14 +562,15 @@ function getTradeInfoDataFromEI(
   const exactSetAmount = displayFromWei(setAmount) ?? '0.0'
   const maxPayment =
     displayFromWei(data.inputTokenAmount, undefined, tokenDecimals) ?? '0.0'
-  // TODO:
-  const networkFee = ''
+  const gasLimit = 1800000 // TODO: Make gasLimit dynamic
+  const networkFee = displayFromWei(gasPrice.mul(gasLimit))
+  const networkFeeDisplay = networkFee ? parseFloat(networkFee).toFixed(4) : '-'
   const networkToken = chainId === ChainId.Polygon ? 'MATIC' : 'ETH'
   const offeredFrom = 'Index - Exchange Issuance'
   return [
     { title: 'Exact Set amount', value: exactSetAmount },
     { title: 'Maximum payment amount', value: maxPayment },
-    { title: 'Network Fee', value: `${networkFee} ${networkToken}` },
+    { title: 'Network Fee', value: `${networkFeeDisplay} ${networkToken}` },
     { title: 'Offered From', value: offeredFrom },
   ]
 }
@@ -594,7 +597,8 @@ function getTradeInfoData0x(
     displayFromWei(zeroExTradeData.minOutput, undefined, tokenDecimals) ?? '0.0'
 
   const networkFee =
-    displayFromWei(BigNumber.from(gasPrice).mul(BigNumber.from(gas))) ?? '-'
+    displayFromWei(BigNumber.from(gasPrice).mul(BigNumber.from(gas)))
+  const networkFeeDisplay = networkFee ? parseFloat(networkFee).toFixed(4) : '-'
   const networkToken = chainId === ChainId.Polygon ? 'MATIC' : 'ETH'
 
   const offeredFromSources = zeroExTradeData.sources
@@ -604,7 +608,7 @@ function getTradeInfoData0x(
   return [
     { title: 'Buy Amount', value: buyAmount },
     { title: 'Minimum Receive', value: minReceive },
-    { title: 'Network Fee', value: `${networkFee} ${networkToken}` },
+    { title: 'Network Fee', value: `${networkFeeDisplay} ${networkToken}` },
     { title: 'Offered From', value: offeredFromSources.toString() },
   ]
 }

--- a/src/hooks/useExchangeIssuanceLeveraged.ts
+++ b/src/hooks/useExchangeIssuanceLeveraged.ts
@@ -95,6 +95,7 @@ export const useExchangeIssuanceLeveraged = () => {
         _maxInput
       })
       
+      //TODO: Estimate better _maxInput. For now hardcode addtional 0.05 ETH
       const higherMax = BigNumber.from(_maxInput).add(BigNumber.from('5000000000000000'))
       console.log('amounts', _maxInput, higherMax)
       const issueSetTx = await eiContract.issueExactSetFromETH(
@@ -102,7 +103,7 @@ export const useExchangeIssuanceLeveraged = () => {
         _setAmount,
         _swapDataDebtForCollateral,
         _swapDataInputToken,
-        { value: higherMax, gasLimit: 1800000, maxFeePerGas:100000000000, maxPriorityFeePerGas: 2000000000 }
+        { value: higherMax, gasLimit: 1800000 }
       )
 
       console.log('finished',issueSetTx)

--- a/src/utils/exchangeIssuanceQuotes.ts
+++ b/src/utils/exchangeIssuanceQuotes.ts
@@ -25,6 +25,7 @@ export interface LeveragedExchangeIssuanceQuote {
   swapDataPaymentToken: SwapData
   inputTokenAmount: BigNumber
   setTokenAmount: BigNumber
+  gasPrice: BigNumber
 }
 
 export enum Exchange {
@@ -264,11 +265,14 @@ export const getLeveragedExchangeIssuanceQuotes = async (
     swapDataPaymentToken.path = []
   }
 
+  const gasPrice = await library?.getGasPrice() ?? BigNumber.from(0)
+
   return {
     swapDataDebtCollateral,
     swapDataPaymentToken,
     inputTokenAmount,
     setTokenAmount,
+    gasPrice
   }
 }
 


### PR DESCRIPTION
## **Summary of Changes**

Fetches gas price and multiplies it by a hardcoded gas limit. 
Still need to add the gas cost estimate to the maximum payment amount  when comparing EI to DEX

## **Test Data or Screenshots**
![Cursor_and_Index_App___Decentralized_Crypto_Index_Funds](https://user-images.githubusercontent.com/1253142/161479607-db834802-b113-46f1-8978-b32c47ab6ce4.png)

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
