### PR TITLE
Fix swapping tokens

### DIFF
--- a/src/components/dashboard/QuickTrade.tsx
+++ b/src/components/dashboard/QuickTrade.tsx
@@ -241,19 +241,6 @@ const QuickTrade = (props: {
   }, [chainId])
 
   useEffect(() => {
-    const prevSellToken = sellToken
-    const prevBuyToken = buyToken
-    const currencyTokensList = getCurrencyTokensByChain()
-    const tokenList = getTokenListByChain()
-    const sellTokenList = isBuying ? currencyTokensList : tokenList
-    const buyTokenList = isBuying ? tokenList : currencyTokensList
-    setSellTokenList(sellTokenList)
-    setBuyTokenList(buyTokenList)
-    setSellToken(prevBuyToken)
-    setBuyToken(prevSellToken)
-  }, [isBuying])
-
-  useEffect(() => {
     const isUSDC = buyToken.symbol === 'USDC'
     const decimals = isUSDC ? 6 : 18
     const formattedBalance = buyTokenBalance
@@ -442,9 +429,18 @@ const QuickTrade = (props: {
   }
 
   const onSwapTokenLists = () => {
-    // It's only necessary to change isBuying - since effect hooks
-    // will do the rest listening to this change
-    setIsBuying(!isBuying)
+    const isBuyingNew = !isBuying
+    const prevSellToken = sellToken
+    const prevBuyToken = buyToken
+    const currencyTokensList = getCurrencyTokensByChain()
+    const tokenList = getTokenListByChain()
+    const sellTokenList = isBuyingNew ? currencyTokensList : tokenList
+    const buyTokenList = isBuyingNew ? tokenList : currencyTokensList
+    setSellTokenList(sellTokenList)
+    setBuyTokenList(buyTokenList)
+    setSellToken(prevBuyToken)
+    setBuyToken(prevSellToken)
+    setIsBuying(isBuyingNew)
   }
 
   const isLoading = getIsApproving() || isFetchingTradeData


### PR DESCRIPTION
## **Summary of Changes**

Fix swapping tokens which could get messed up when switching chains. This was due to the hook listening to `isBuying` which previously was only changed by the `onSwapTokenLists` but now is also reset when the chain changes - resulting in weird behaviors.

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
