### PR TITLE
Hotfix/ei slippage

### DIFF
--- a/src/components/dashboard/QuickTradeFormatter.ts
+++ b/src/components/dashboard/QuickTradeFormatter.ts
@@ -66,7 +66,7 @@ export function getTradeInfoDataFromEI(
   const networkToken = chainId === ChainId.Polygon ? 'MATIC' : 'ETH'
   const offeredFrom = 'Index - Exchange Issuance'
   return [
-    { title: `Exact Amount of Received`, value: exactSetAmount },
+    { title: `Exact Amount Received`, value: exactSetAmount },
     { title: 'Maximum Payment Amount', value: maxPayment },
     { title: 'Network Fee', value: `${networkFeeDisplay} ${networkToken}` },
     { title: 'Offered From', value: offeredFrom },

--- a/src/hooks/useExchangeIssuanceLeveraged.ts
+++ b/src/hooks/useExchangeIssuanceLeveraged.ts
@@ -183,8 +183,8 @@ export const useExchangeIssuanceLeveraged = () => {
       )
       // TODO: calculate more accurate _maxAmountInputToken so it doesn't revert
       const higherMax = BigNumber.from(_maxAmountInputToken)
-        .mul(10025)
-        .div(10000) // Extra 0.25%
+        .mul(10050)
+        .div(10000) // Extra 0.50%
       console.log('erc20', {
         _setToken,
         _setAmount,


### PR DESCRIPTION
## **Summary of Changes**

This should fix the failing transactions due to CURVE_OVERSPENT error. However, this still needs improvement for 2 reasons:
1) It causes the Maximum Payment Amount to be higher than what the user inputs
![Index_App___Decentralized_Crypto_Index_Funds](https://user-images.githubusercontent.com/1253142/162437346-de8435e4-6e4e-4c8b-b3bc-5c4d187b12ca.png)
2) It isn't reflected in the calculation that determines wether EI is cheaper than DEX swap. 

## **Test Data or Screenshots**

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
