### PR TITLE
fix: Quick Trade remove irrelevant input tooltip

### DIFF
--- a/src/components/dashboard/QuickTradeSelector.tsx
+++ b/src/components/dashboard/QuickTradeSelector.tsx
@@ -100,6 +100,7 @@ const QuickTradeSelector = (props: {
           <Input
             placeholder='0.0'
             type='number'
+            step='any'
             variant='unstyled'
             disabled={config.isInputDisabled ?? false}
             isReadOnly={config.isReadOnly ?? false}


### PR DESCRIPTION
## **Summary of Changes**

Issue:
Input tooltip appears when input amount is a float

<img width="355" alt="Screen Shot 2022-04-13 at 7 13 13 PM" src="https://user-images.githubusercontent.com/13758946/163142754-785d6e23-de87-4c72-a18c-f2d6401f7a6f.png">

Fix:
Remove tooltip by setting input step to any

&nbsp;

## **Test Data or Screenshots**

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
