### PR TITLE
fix: useApproval hook not updating on amount change

### DIFF
--- a/src/hooks/useApproval.ts
+++ b/src/hooks/useApproval.ts
@@ -51,6 +51,7 @@ export const useApproval = (
     }
   }, [
     account,
+    amount,
     library,
     setIsApproved,
     setIsApproving,


### PR DESCRIPTION
## **Summary of Changes**

Issue:
useApproval handler (used in selling products in the Quick Trade widget) does not update amount on change, so the amount is always 0

<img width="737" alt="Screen Shot 2022-04-09 at 9 12 58 AM" src="https://user-images.githubusercontent.com/13758946/163181499-2f9d5801-8bd1-4cd4-b478-58ff0e4db290.png">

Fix:
Add amount to useCallback dependency

&nbsp;

## **Test Data or Screenshots**

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
