### PR TITLE
fix: Quick Trade Balance input full balance

### DIFF
--- a/src/components/dashboard/QuickTradeFormatter.ts
+++ b/src/components/dashboard/QuickTradeFormatter.ts
@@ -11,6 +11,9 @@ import { ZeroExData } from 'utils/zeroExUtils'
 
 import { TradeInfoItem } from './TradeInfo'
 
+/**
+ * Rounds to 2 decimal places. NOT precise, should only be used for display
+ */
 export function formattedBalance(
   token: Token,
   tokenBalance: BigNumber | undefined

--- a/src/components/dashboard/QuickTradeSelector.tsx
+++ b/src/components/dashboard/QuickTradeSelector.tsx
@@ -4,6 +4,7 @@ import { BigNumber } from 'set.js'
 import { colors } from 'styles/colors'
 
 import { Box, Flex, Image, Input, Select, Text } from '@chakra-ui/react'
+import { formatUnits } from '@ethersproject/units'
 import { useEthers } from '@usedapp/core'
 
 import { Token } from 'constants/tokens'
@@ -149,7 +150,13 @@ const QuickTradeSelector = (props: {
         fontWeight='400'
         mt='5px'
         onClick={() => {
-          if (tokenBalance) onChangeInput(tokenBalance)
+          if (tokenBalance) {
+            const fullTokenBalance = formatUnits(
+              getBalance(props.selectedToken) ?? '0',
+              props.selectedToken.decimals
+            )
+            onChangeInput(fullTokenBalance)
+          }
         }}
         cursor='pointer'
       >


### PR DESCRIPTION
## **Summary of Changes**

Issue:
Quick Trade `Balance` current inputs the display value (rounded to 2 decimal places), this causes two issue if the full balance is greater than 2 decimals
- will result in dust amounts being left (poor UX)
- may have the trade button correctly show Insufficient Funds (ex. displays 5.33, but actual is 5.326)

<img width="816" alt="Screen Shot 2022-04-09 at 8 13 14 PM" src="https://user-images.githubusercontent.com/13758946/163189168-58e124d8-49f8-4717-b88a-df9e622804cb.png">

Fix:
Input the full balance without rounding

<img width="452" alt="Screen Shot 2022-04-13 at 11 16 13 PM" src="https://user-images.githubusercontent.com/13758946/163189494-e59448d8-bb61-4428-8337-b60d82136fc0.png">

&nbsp;

## **Test Data or Screenshots**

Tested locally with several products of various amounts

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
