### PR TITLE
Update price formatting for product page header

### DIFF
--- a/src/components/product/MarketChart.tsx
+++ b/src/components/product/MarketChart.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts'
 import { colors, useICColorMode } from 'styles/colors'
 
-import { Box, Flex, Spacer } from '@chakra-ui/layout'
+import { Box, Flex } from '@chakra-ui/layout'
 import { Tab, TabList, Tabs, Text, useTheme } from '@chakra-ui/react'
 
 export enum Durations {

--- a/src/components/product/ProductPage.tsx
+++ b/src/components/product/ProductPage.tsx
@@ -116,7 +116,11 @@ const ProductPage = (props: {
 
   const priceChartData = getPriceChartData([marketData])
 
-  const price = `$${selectLatestMarketData(marketData.hourlyPrices).toFixed(2)}`
+  const price = selectLatestMarketData(marketData.hourlyPrices).toLocaleString(
+    'en-US',
+    { minimumFractionDigits: 2, maximumFractionDigits: 2 }
+  )
+  const priceFormatted = `$${price}`
   const priceChanges = getPricesChanges(marketData.hourlyPrices ?? [])
   const priceChangesFormatted = getFormattedChartPriceChanges(priceChanges)
 
@@ -138,7 +142,7 @@ const ProductPage = (props: {
           <Flex direction={['column', 'column', 'column', 'row']}>
             <MarketChart
               marketData={priceChartData}
-              prices={[price]}
+              prices={[priceFormatted]}
               priceChanges={priceChangesFormatted}
               options={{
                 width: chartWidth,


### PR DESCRIPTION
## **Summary of Changes**
Adds better formatting for index prices in product page header.

<img width="1512" alt="numbers" src="https://user-images.githubusercontent.com/2104965/164027985-92fc61e4-5dda-4245-a3fc-a83dcfc85f2c.png">

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
