### PR TITLE
Fix history table dom

### DIFF
--- a/src/components/dashboard/TransactionHistoryTable.tsx
+++ b/src/components/dashboard/TransactionHistoryTable.tsx
@@ -67,7 +67,7 @@ const TableHeader = () => {
             <Th>From</Th>
             {!isTablet && <Th></Th>}
             <Th>To</Th>
-            {!isTablet && <Th>Transaction</Th>}{' '}
+            {!isTablet && <Th>Transaction</Th>}
           </>
         )}
         <Th></Th>


### PR DESCRIPTION
## **Summary of Changes**
Removes empty space to avoid errors in dom of history table (on dashboard).

Error did appear in the console locally and on sentry:
`Warning: validateDOMNesting(...): Whitespace text nodes cannot appear as a child of <tr>. Make sure you don't have any extra whitespace between tags on each line of your source code.`

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
