### PR TITLE
Fix redeeming for 0x EI

### DIFF
--- a/src/hooks/useTradeExchangeIssuance.ts
+++ b/src/hooks/useTradeExchangeIssuance.ts
@@ -95,7 +95,8 @@ export const useTradeExchangeIssuance = (
         }
       } else {
         const isRedeemingNativeChainToken =
-          inputToken.symbol === ETH.symbol || inputToken.symbol === MATIC.symbol
+          outputToken.symbol === ETH.symbol ||
+          outputToken.symbol === MATIC.symbol
         const minOutputReceive = quoteData.inputTokenAmount
 
         if (isRedeemingNativeChainToken) {


### PR DESCRIPTION
## **Summary of Changes**

Fixes native chain token check when redeeming - which caused to pick the wrong redeem function for the 0x EI.

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
