### PR TITLE
Add output token amount formatter

### DIFF
--- a/src/components/dashboard/QuickTrade.tsx
+++ b/src/components/dashboard/QuickTrade.tsx
@@ -40,6 +40,7 @@ import { isSupportedNetwork, isValidTokenInput, toWei } from 'utils'
 
 import {
   formattedFiat,
+  getFormattedOuputTokenAmount,
   getFormattedPriceImpact,
   getHasInsufficientFunds,
   getTradeInfoData0x,
@@ -81,6 +82,7 @@ const QuickTrade = (props: {
   const [bestOption, setBestOption] = useState<QuickTradeBestOption | null>(
     null
   )
+  const [buyTokenAmountFormatted, setBuyTokenAmountFormatted] = useState('0.0')
   const [sellTokenAmount, setSellTokenAmount] = useState('0')
   const [tradeInfoData, setTradeInfoData] = useState<TradeInfoItem[]>([])
 
@@ -100,10 +102,6 @@ const QuickTrade = (props: {
       : ExchangeIssuanceLeveragedMainnetAddress
 
   const sellTokenAmountInWei = toWei(sellTokenAmount, sellToken.decimals)
-  const buyTokenAmountFormatted =
-    (bestOption === QuickTradeBestOption.zeroEx
-      ? tradeInfoData[0]?.value
-      : tradeInfoData[1]?.value) ?? '0'
 
   const sellTokenFiat = formattedFiat(
     parseFloat(sellTokenAmount),
@@ -260,9 +258,19 @@ const QuickTrade = (props: {
           isBuying
         )
 
+    const buyTokenAmountFormatted = getFormattedOuputTokenAmount(
+      bestOption !== QuickTradeBestOption.zeroEx,
+      buyToken.decimals,
+      bestOptionResult?.success
+        ? bestOptionResult.dexData?.minOutput
+        : undefined,
+      isBuying ? tradeDataEI?.setTokenAmount : tradeDataEI?.inputTokenAmount
+    )
+
     console.log('BESTOPTION', bestOption)
     setTradeInfoData(tradeInfoData)
     setBestOption(bestOption)
+    setBuyTokenAmountFormatted(buyTokenAmountFormatted)
   }, [bestOptionResult])
 
   useEffect(() => {

--- a/src/components/dashboard/QuickTradeFormatter.ts
+++ b/src/components/dashboard/QuickTradeFormatter.ts
@@ -63,6 +63,32 @@ export function formattedBalance(
     : zero
 }
 
+export function getFormattedOuputTokenAmount(
+  bestOptionIsTypeEI: boolean,
+  ouputTokenDecimals: number,
+  zeroExTradeDataOutputAmount: BigNumber | undefined,
+  exchangeIssuanceOutputAmount: BigNumber | undefined
+): string {
+  if (
+    (bestOptionIsTypeEI && !exchangeIssuanceOutputAmount) ||
+    (!bestOptionIsTypeEI && !zeroExTradeDataOutputAmount)
+  ) {
+    return '0.0'
+  }
+
+  if (bestOptionIsTypeEI) {
+    return (
+      displayFromWei(
+        exchangeIssuanceOutputAmount,
+        undefined,
+        ouputTokenDecimals
+      ) ?? '0.0'
+    )
+  }
+
+  return displayFromWei(zeroExTradeDataOutputAmount) ?? '0.0'
+}
+
 export function formattedFiat(tokenAmount: number, tokenPrice: number): string {
   const price = (tokenAmount * tokenPrice).toLocaleString('en-US', {
     minimumFractionDigits: 2,
@@ -128,9 +154,6 @@ export function getTradeInfoDataFromEI(
 ): TradeInfoItem[] {
   if (data === undefined || data === null) return []
   const exactSetAmount = displayFromWei(setAmount) ?? '0.0'
-
-  // TODO: connect this amount to the value from
-  // useExchangeIssuanceLeveraged: issueExactSetFromETH()
   const inputTokenMax = data.inputTokenAmount.mul(10050).div(10000)
   const maxPayment = displayFromWei(inputTokenMax) ?? '0.0'
   const gasLimit = 1800000 // TODO: Make gasLimit dynamic


### PR DESCRIPTION
## **Summary of Changes**

Adds formatter for output token amount.

Before this was done in a hacky way which already broke a couple of times. Now it's based on the available trade data taking into account the best option.

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
