### PR TITLE
Add always fetch exchange issuance quotes

### DIFF
--- a/src/hooks/useBestTradeOption.ts
+++ b/src/hooks/useBestTradeOption.ts
@@ -139,52 +139,50 @@ export const useBestTradeOption = () => {
     let leveragedExchangeIssuanceOption: LeveragedExchangeIssuanceQuote | null =
       null
 
-    if (account) {
-      const tokenEligibleForLeveragedEI = isEligibleTradePair(
-        sellToken,
-        buyToken,
-        isIssuance
-      )
-      if (tokenEligibleForLeveragedEI) {
-        const setToken = isIssuance ? buyToken : sellToken
+    const tokenEligibleForLeveragedEI = isEligibleTradePair(
+      sellToken,
+      buyToken,
+      isIssuance
+    )
+    if (tokenEligibleForLeveragedEI) {
+      const setToken = isIssuance ? buyToken : sellToken
 
-        try {
-          leveragedExchangeIssuanceOption =
-            await getLeveragedExchangeIssuanceQuotes(
-              setToken,
-              setTokenAmount,
-              sellToken,
-              isIssuance,
-              chainId,
-              library
-            )
-        } catch (e) {
-          console.warn('error when generating leveraged ei option', e)
-        }
-      } else {
-        const isIcEth =
-          sellToken.symbol === icETHIndex.symbol ||
-          buyToken.symbol === icETHIndex.symbol
-        const isJpg =
-          sellToken.symbol === JPGIndex.symbol ||
-          buyToken.symbol === JPGIndex.symbol
-        // For now only run on mainnet and if not icETH
-        // icETH token pair (with non ETH token) could not be eligible and land here
-        // temporarily - disabled JPG for EI
-        if (chainId === MAINNET.chainId && !isIcEth && !isJpg)
-          try {
-            exchangeIssuanceOption = await getExchangeIssuanceQuotes(
-              buyToken,
-              setTokenAmount,
-              sellToken,
-              isIssuance,
-              chainId,
-              library
-            )
-          } catch (e) {
-            console.warn('error when generating zeroexei option', e)
-          }
+      try {
+        leveragedExchangeIssuanceOption =
+          await getLeveragedExchangeIssuanceQuotes(
+            setToken,
+            setTokenAmount,
+            sellToken,
+            isIssuance,
+            chainId,
+            library
+          )
+      } catch (e) {
+        console.warn('error when generating leveraged ei option', e)
       }
+    } else {
+      const isIcEth =
+        sellToken.symbol === icETHIndex.symbol ||
+        buyToken.symbol === icETHIndex.symbol
+      const isJpg =
+        sellToken.symbol === JPGIndex.symbol ||
+        buyToken.symbol === JPGIndex.symbol
+      // For now only run on mainnet and if not icETH
+      // icETH token pair (with non ETH token) could not be eligible and land here
+      // temporarily - disabled JPG for EI
+      if (chainId === MAINNET.chainId && !isIcEth && !isJpg)
+        try {
+          exchangeIssuanceOption = await getExchangeIssuanceQuotes(
+            buyToken,
+            setTokenAmount,
+            sellToken,
+            isIssuance,
+            chainId,
+            library
+          )
+        } catch (e) {
+          console.warn('error when generating zeroexei option', e)
+        }
     }
 
     console.log(

--- a/src/utils/exchangeIssuanceGasEstimate.ts
+++ b/src/utils/exchangeIssuanceGasEstimate.ts
@@ -36,7 +36,7 @@ export async function getExchangeIssuanceGasEstimate(
 
   try {
     const contract = await getExchangeIssuanceZeroExContract(
-      library?.getSigner(),
+      library,
       chainId ?? ChainId.Mainnet
     )
 

--- a/src/utils/exchangeIssuanceQuotes.ts
+++ b/src/utils/exchangeIssuanceQuotes.ts
@@ -93,12 +93,12 @@ export async function getRequiredComponents(
   setTokenSymbol: string,
   setTokenAmount: BigNumber,
   chainId: ChainId | undefined,
-  signer: ethers.Signer | undefined
+  provider: ethers.providers.Web3Provider | undefined
 ) {
   const issuanceModule = getIssuanceModule(setTokenSymbol, chainId)
 
   const contract = await getExchangeIssuanceZeroExContract(
-    signer,
+    provider,
     chainId ?? ChainId.Mainnet
   )
 
@@ -139,7 +139,7 @@ export const getExchangeIssuanceQuotes = async (
   sellToken: Token,
   isIssuance: boolean,
   chainId: ChainId = ChainId.Mainnet,
-  library: ethers.providers.Web3Provider | undefined
+  provider: ethers.providers.Web3Provider | undefined
 ): Promise<ExchangeIssuanceQuote | null> => {
   const isPolygon = chainId === ChainId.Polygon
   const buyTokenAddress = isPolygon ? buyToken.polygonAddress : buyToken.address
@@ -157,7 +157,7 @@ export const getExchangeIssuanceQuotes = async (
     setTokenSymbol,
     setTokenAmount,
     chainId,
-    library?.getSigner()
+    provider
   )
 
   let positionQuotes: string[] = []
@@ -235,13 +235,13 @@ export const getExchangeIssuanceQuotes = async (
       )
     )
 
-  const gasPrice = (await library?.getGasPrice()) ?? BigNumber.from(1800000)
+  const gasPrice = (await provider?.getGasPrice()) ?? BigNumber.from(1800000)
 
   // TODO: get balance and check if inputAmount exceeds balance
   // TODO: only fetch gasEstimate if inputAmount <= balance
   // TODO: otherwise skip, to still return a quote
   const gasEstimate = await getExchangeIssuanceGasEstimate(
-    library,
+    provider,
     chainId,
     isIssuance,
     sellToken,
@@ -277,7 +277,7 @@ async function getLevTokenData(
   setTokenAmount: BigNumber,
   isIssuance: boolean,
   chainId: number,
-  signer: ethers.providers.JsonRpcSigner | undefined
+  signer: ethers.providers.Web3Provider | undefined
 ): Promise<LeveragedTokenData> {
   const contract = await getExchangeIssuanceLeveragedContract(signer, chainId)
   const setTokenAddress = getAddressForToken(setToken, chainId)
@@ -383,7 +383,7 @@ export const getLeveragedExchangeIssuanceQuotes = async (
   paymentToken: Token,
   isIssuance: boolean,
   chainId: ChainId = ChainId.Mainnet,
-  library: ethers.providers.Web3Provider | undefined
+  provider: ethers.providers.Web3Provider | undefined
 ): Promise<LeveragedExchangeIssuanceQuote | null> => {
   const tokenSymbol = setToken.symbol
   const isIcEth = tokenSymbol === 'icETH'
@@ -394,7 +394,7 @@ export const getLeveragedExchangeIssuanceQuotes = async (
     setTokenAmount,
     isIssuance,
     chainId,
-    library?.getSigner()
+    provider
   )
 
   let debtCollateralResult = isIssuance
@@ -448,7 +448,7 @@ export const getLeveragedExchangeIssuanceQuotes = async (
       chainId
     )
 
-  const gasPrice = (await library?.getGasPrice()) ?? BigNumber.from(0)
+  const gasPrice = (await provider?.getGasPrice()) ?? BigNumber.from(0)
 
   return {
     swapDataDebtCollateral,


### PR DESCRIPTION
## **Summary of Changes**

Activates always fetching exchange issuance quotes - no matter if the user connected a wallet or not. Before this was only working when a wallet is connected.

No changes were necessary for the provider or their config. Just made the mistake to specifically use a signer before while the provider will actually automatically pick the `read-only` provider if a signer like MetaMask is not connected.

&nbsp;

## **Test Data or Screenshots**

* Everything should work as before. Tests ✅ 

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
