### PR TITLE
Enhance select token modal

### DIFF
--- a/src/components/dashboard/QuickTrade.tsx
+++ b/src/components/dashboard/QuickTrade.tsx
@@ -514,7 +514,9 @@ const QuickTrade = (props: {
           formattedFiat={sellTokenFiat}
           tokenList={sellTokenList}
           onChangeInput={onChangeSellTokenAmount}
-          onSelectedToken={(_) => onOpenSelectInputToken()}
+          onSelectedToken={(_) => {
+            if (inputTokenItems.length > 1) onOpenSelectInputToken()
+          }}
         />
         <Box h='12px' alignSelf={'flex-end'} m={'-12px 0 12px 0'}>
           <IconButton
@@ -542,7 +544,9 @@ const QuickTrade = (props: {
           priceImpact={priceImpact ?? undefined}
           tokenList={buyTokenList}
           onChangeInput={(token: Token, input: string) => {}}
-          onSelectedToken={(_) => onOpenSelectOutputToken()}
+          onSelectedToken={(_) => {
+            if (outputTokenItems.length > 1) onOpenSelectOutputToken()
+          }}
         />
       </Flex>
       <Flex direction='column'>


### PR DESCRIPTION
## **Summary of Changes**
Adds a check to only open the select token modal if there are more than one input/output tokens to show.

This is mainly relevant for product pages - as they limit the trade comp to only have the set token as input/output.

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
