### PR TITLE
Fix leveraged exchange issuance quotes

### DIFF
--- a/src/hooks/useBestTradeOption.ts
+++ b/src/hooks/useBestTradeOption.ts
@@ -156,6 +156,7 @@ export const useBestTradeOption = () => {
             setToken,
             setTokenAmount,
             sellToken,
+            buyToken,
             isIssuance,
             chainId,
             library

--- a/src/utils/exchangeIssuanceQuotes.ts
+++ b/src/utils/exchangeIssuanceQuotes.ts
@@ -410,7 +410,8 @@ export function getSlippageAdjustedTokenAmount(
 export const getLeveragedExchangeIssuanceQuotes = async (
   setToken: Token,
   setTokenAmount: BigNumber,
-  paymentToken: Token,
+  inputToken: Token,
+  outputToken: Token,
   isIssuance: boolean,
   chainId: ChainId = ChainId.Mainnet,
   provider: ethers.providers.Web3Provider | undefined
@@ -460,8 +461,8 @@ export const getLeveragedExchangeIssuanceQuotes = async (
     collateralObtainedOrSold
   )
 
-  let paymentTokenAddress = getLevEIPaymentTokenAddress(
-    paymentToken,
+  let inputOutputTokenAddress = getLevEIPaymentTokenAddress(
+    isIssuance ? inputToken : outputToken,
     isIssuance,
     chainId
   )
@@ -472,18 +473,20 @@ export const getLeveragedExchangeIssuanceQuotes = async (
       leveragedTokenData.collateralToken,
       collateralShortfall,
       leftoverCollateral,
-      paymentTokenAddress,
+      inputOutputTokenAddress,
       includedSources,
       isIssuance,
       chainId
     )
 
+  const inputOuputTokenDecimals = isIssuance
+    ? inputToken.decimals
+    : outputToken.decimals
   const slip = !isIssuance && isIcEth ? 5 : slippagePercentage
-
   // Need to add some slippage similar to EI quote - as there were failed tx
   paymentTokenAmount = getSlippageAdjustedTokenAmount(
     paymentTokenAmount,
-    paymentToken.decimals,
+    inputOuputTokenDecimals,
     slip,
     isIssuance
   )


### PR DESCRIPTION
## **Summary of Changes**

Fixes leveraged exchange issuance quotes which were using wrong tokens (and token decimals) for redeeming.

&nbsp;


###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
