### PR TITLE
Fix approving tokens

### DIFF
--- a/src/hooks/useApproval.ts
+++ b/src/hooks/useApproval.ts
@@ -4,7 +4,7 @@ import { ethers, utils } from 'ethers'
 
 import { BigNumber } from '@ethersproject/bignumber'
 import { Contract } from '@ethersproject/contracts'
-import { useEthers, useSendTransaction, useTokenAllowance } from '@usedapp/core'
+import { useEthers, useTokenAllowance } from '@usedapp/core'
 
 import { Token } from 'constants/tokens'
 import { ERC20_ABI } from 'utils/abi/ERC20'
@@ -46,7 +46,6 @@ export const useApproval = (
   amount: BigNumber = ethers.constants.MaxUint256
 ) => {
   const { account, chainId, library } = useEthers()
-  const { sendTransaction, state } = useSendTransaction()
 
   const tokenAddress = token && getAddressForToken(token, chainId)
   const approvalState = useApprovalState(amount, tokenAddress, spenderAddress)
@@ -66,11 +65,12 @@ export const useApproval = (
         library.getSigner()
       )
       const tx = await tokenContract.approve(spenderAddress, amount)
-      await sendTransaction(tx)
-    } catch (e) {
-      console.log('Error approving token', tokenAddress, e)
+      const receipt = await tx.wait()
+      setIsApproved(receipt.status === 1)
       setIsApproving(false)
-      return false
+    } catch (e) {
+      setIsApproving(false)
+      console.error('Error approving token', tokenAddress, e)
     }
   }, [
     account,
@@ -85,17 +85,6 @@ export const useApproval = (
   useEffect(() => {
     setIsApproved(approvalState === ApprovalState.Approved)
   }, [approvalState])
-
-  useEffect(() => {
-    const txIsFinished =
-      state.status === 'Success' ||
-      state.status === 'Fail' ||
-      state.status === 'Exception'
-    if (txIsFinished) {
-      setIsApproved(state.status !== 'Fail')
-      setIsApproving(false)
-    }
-  }, [state])
 
   return {
     isApproved,


### PR DESCRIPTION
## **Summary of Changes**

Adds using ethers' tx.wait() (instead of using usedapp) to wait for tx receipt/state. Thus blocking the UI with would should be the correct `isApproving` status until the tx is mined. This hopefully gets rid of users having issues with approvals cause `isApproving` was returning `false` too quick - so they could already _trade_ but weren't approved yet.

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
