### PR TITLE
Fix 0x exchange issuance address for approvals

### DIFF
--- a/src/components/dashboard/QuickTrade.tsx
+++ b/src/components/dashboard/QuickTrade.tsx
@@ -10,11 +10,7 @@ import { useEthers } from '@usedapp/core'
 
 import ConnectModal from 'components/header/ConnectModal'
 import { MAINNET, OPTIMISM, POLYGON } from 'constants/chains'
-import {
-  ExchangeIssuanceLeveragedMainnetAddress,
-  ExchangeIssuanceLeveragedPolygonAddress,
-  zeroExRouterAddress,
-} from 'constants/ethContractAddresses'
+import { zeroExRouterAddress } from 'constants/ethContractAddresses'
 import {
   indexNamesMainnet,
   indexNamesOptimism,
@@ -29,7 +25,10 @@ import { useTradeExchangeIssuance } from 'hooks/useTradeExchangeIssuance'
 import { useTradeLeveragedExchangeIssuance } from 'hooks/useTradeLeveragedExchangeIssuance'
 import { useTradeTokenLists } from 'hooks/useTradeTokenLists'
 import { isSupportedNetwork, isValidTokenInput, toWei } from 'utils'
-import { get0xExchangeIssuanceContract } from 'utils/contracts'
+import {
+  get0xExchangeIssuanceContract,
+  getLeveragedExchangeIssuanceContract,
+} from 'utils/contracts'
 
 import {
   formattedFiat,
@@ -98,10 +97,7 @@ const QuickTrade = (props: {
     bestOptionResult && !bestOptionResult.success && !isFetchingTradeData
 
   const spenderAddress0x = get0xExchangeIssuanceContract(chainId)
-  const spenderAddressLevEIL =
-    chainId === POLYGON.chainId
-      ? ExchangeIssuanceLeveragedPolygonAddress
-      : ExchangeIssuanceLeveragedMainnetAddress
+  const spenderAddressLevEIL = getLeveragedExchangeIssuanceContract(chainId)
 
   const sellTokenAmountInWei = toWei(sellTokenAmount, sellToken.decimals)
 

--- a/src/utils/contracts.test.ts
+++ b/src/utils/contracts.test.ts
@@ -1,9 +1,14 @@
 import {
+  ExchangeIssuanceLeveragedMainnetAddress,
+  ExchangeIssuanceLeveragedPolygonAddress,
   ExchangeIssuanceZeroExMainnetAddress,
   ExchangeIssuanceZeroExPolygonAddress,
 } from 'constants/ethContractAddresses'
 
-import { get0xExchangeIssuanceContract } from './contracts'
+import {
+  get0xExchangeIssuanceContract,
+  getLeveragedExchangeIssuanceContract,
+} from './contracts'
 
 describe('get0xExchangeIssuanceContract()', () => {
   test('return correct address for polygon', async () => {
@@ -15,6 +20,20 @@ describe('get0xExchangeIssuanceContract()', () => {
   test('return correct address for mainnet', async () => {
     const expectedAddress = ExchangeIssuanceZeroExMainnetAddress
     const address = get0xExchangeIssuanceContract(1)
+    expect(address).toEqual(expectedAddress)
+  })
+})
+
+describe('getLeveragedExchangeIssuanceContract()', () => {
+  test('return correct address for polygon', async () => {
+    const expectedAddress = ExchangeIssuanceLeveragedPolygonAddress
+    const address = getLeveragedExchangeIssuanceContract(137)
+    expect(address).toEqual(expectedAddress)
+  })
+
+  test('return correct address for mainnet', async () => {
+    const expectedAddress = ExchangeIssuanceLeveragedMainnetAddress
+    const address = getLeveragedExchangeIssuanceContract(1)
     expect(address).toEqual(expectedAddress)
   })
 })

--- a/src/utils/contracts.ts
+++ b/src/utils/contracts.ts
@@ -1,5 +1,7 @@
 import { POLYGON } from 'constants/chains'
 import {
+  ExchangeIssuanceLeveragedMainnetAddress,
+  ExchangeIssuanceLeveragedPolygonAddress,
   ExchangeIssuanceZeroExMainnetAddress,
   ExchangeIssuanceZeroExPolygonAddress,
 } from 'constants/ethContractAddresses'
@@ -7,4 +9,12 @@ import {
 export function get0xExchangeIssuanceContract(chainId: number = 1): string {
   if (chainId === POLYGON.chainId) return ExchangeIssuanceZeroExPolygonAddress
   return ExchangeIssuanceZeroExMainnetAddress
+}
+
+export function getLeveragedExchangeIssuanceContract(
+  chainId: number = 1
+): string {
+  if (chainId === POLYGON.chainId)
+    return ExchangeIssuanceLeveragedPolygonAddress
+  return ExchangeIssuanceLeveragedMainnetAddress
 }


### PR DESCRIPTION
## **Summary of Changes**

Fixes picking the right address for the 0x exchange issuance based on chain id.

Essentially, just addresses were mixed up. Added new utility functions to accommodate for any future chains. 

&nbsp;

## **Test Data or Screenshots**

Added new tests for the utility functions. ✅ 

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
