### PR TITLE
added affiliateAddress to 0x

### DIFF
--- a/src/constants/ethContractAddresses.ts
+++ b/src/constants/ethContractAddresses.ts
@@ -97,7 +97,7 @@ export const tradeModuleOptimismAddress =
 export const protocolViewerOptimismAddress =
   '0x4E05073560B9377E5561B559c9cADBbe7112e38f'
 export const slippageIssuanceModuleOptimismAddress =
-  '0x1db929398958082d2080AA1B501e460503f60467'
+  '0x2B67D4F9407F772374CaE8B010dB36A770C2c3ae'
 export const perpV2BasisTradingModuleOptimismAddress =
   '0x2C229EE3aD3fdC0e581d51BaA6b6f45CC9A6Ca39'
 export const perpV2BasisTradingModuleViewerOptimismAddress =
@@ -114,3 +114,5 @@ export const streamingFeeExtensionOptimismAddress =
   '0x6a7aE5124677314dc32C5ba3004CbFC9c7Febff0'
 export const tradeExtensionOptimismAddress =
   '0x7215f38011C3e4058Ca3cF7d2b99033016EeFBD8'
+export const deltaNeutralBasisTradingStrategyExtension =
+  '0x95e24048AB1A9086b2F06107dF7ec5e61961951A'

--- a/src/utils/zeroExUtils.ts
+++ b/src/utils/zeroExUtils.ts
@@ -52,8 +52,8 @@ function getApiUrl(query: string, chainId: number): string {
       networkKey = 'mainnet'
   }
 
-  // example: https://api.indexcoop.com/0x/mainnet/swap/v1/quote?sellToken=ETH&buyToken=0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b&sellAmount=10000000000000000000
-  return `${API_0X_INDEX_URL}/${networkKey}${quotePath}?${query}`
+  // example: https://api.indexcoop.com/0x/mainnet/swap/v1/quote?sellToken=ETH&buyToken=0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b&sellAmount=10000000000000000000&affilliateAddress=0x37e6365d4f6aE378467b0e24c9065Ce5f06D70bF
+  return `${API_0X_INDEX_URL}/${networkKey}${quotePath}?${query}&affilliateAddress=0x37e6365d4f6aE378467b0e24c9065Ce5f06D70bF`
 }
 
 // Temporarily adding this because we need to support more tokens than the once


### PR DESCRIPTION
## **Summary of Changes**
- Added `&affiliateAddress=0x37e6365d4f6aE378467b0e24c9065Ce5f06D70bF` to the end of API URL
- updated (currently unused) contract addresses

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/SetProtocol/index-ui/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
