### PR TITLE
Add contract view

### DIFF
--- a/src/components/dashboard/ContractExecutionView.tsx
+++ b/src/components/dashboard/ContractExecutionView.tsx
@@ -1,0 +1,29 @@
+import { Flex, Link, Text } from '@chakra-ui/react'
+
+type ContractExecutionViewProps = {
+  blockExplorerUrl: string
+  contractAddress: string
+  name: string
+}
+
+export const ContractExecutionView = (props: ContractExecutionViewProps) => (
+  <Flex
+    direction='column'
+    align='center'
+    justify='center'
+    mt='16px'
+    fontSize='11px'
+  >
+    <Text>
+      {`This trade will be executed on contract:`}
+      <br />
+    </Text>
+    <Link
+      href={props.blockExplorerUrl}
+      isExternal
+      style={{ textDecoration: 'underline' }}
+    >
+      {props.contractAddress}
+    </Link>
+  </Flex>
+)

--- a/src/components/dashboard/QuickTrade.tsx
+++ b/src/components/dashboard/QuickTrade.tsx
@@ -37,12 +37,14 @@ import { useTradeExchangeIssuance } from 'hooks/useTradeExchangeIssuance'
 import { useTradeLeveragedExchangeIssuance } from 'hooks/useTradeLeveragedExchangeIssuance'
 import { useTradeTokenLists } from 'hooks/useTradeTokenLists'
 import { isSupportedNetwork, isValidTokenInput, toWei } from 'utils'
+import { getBlockExplorerContractUrl } from 'utils/blockExplorer'
 import {
   get0xExchangeIssuanceContract,
   getLeveragedExchangeIssuanceContract,
 } from 'utils/contracts'
 import { getFullCostsInUsd } from 'utils/exchangeIssuanceQuotes'
 
+import { ContractExecutionView } from './ContractExecutionView'
 import {
   formattedFiat,
   getFormattedOuputTokenAmount,
@@ -203,6 +205,24 @@ const QuickTrade = (props: {
     bestOption === null,
     sellTokenAmountInWei,
     getBalance(sellToken.symbol)
+  )
+
+  const getContractForBestOption = (
+    bestOption: QuickTradeBestOption | null
+  ): string => {
+    switch (bestOption) {
+      case QuickTradeBestOption.exchangeIssuance:
+        return spenderAddress0x
+      case QuickTradeBestOption.leveragedExchangeIssuance:
+        return spenderAddressLevEIL
+      default:
+        return zeroExRouterAddress
+    }
+  }
+  const contractBestOption = getContractForBestOption(bestOption)
+  const contractBlockExplorerUrl = getBlockExplorerContractUrl(
+    contractBestOption,
+    chainId
   )
 
   /**
@@ -615,6 +635,13 @@ const QuickTrade = (props: {
             isDisabled={isButtonDisabled}
             isLoading={isLoading}
             onClick={onClickTradeButton}
+          />
+        )}
+        {bestOption !== null && (
+          <ContractExecutionView
+            blockExplorerUrl={contractBlockExplorerUrl}
+            contractAddress={contractBestOption}
+            name=''
           />
         )}
       </Flex>

--- a/src/utils/blockExplorer.ts
+++ b/src/utils/blockExplorer.ts
@@ -1,5 +1,19 @@
 import { MAINNET, OPTIMISM, POLYGON } from 'constants/chains'
 
+export function getBlockExplorerContractUrl(
+  contractAddress: string,
+  chainId?: number
+): string {
+  switch (chainId) {
+    case OPTIMISM.chainId:
+      return OPTIMISM.blockExplorerUrl + 'address/' + contractAddress
+    case POLYGON.chainId:
+      return POLYGON.blockExplorerUrl + 'address/' + contractAddress
+    default:
+      return MAINNET.blockExplorerUrl + 'address/' + contractAddress
+  }
+}
+
 export function getBlockExplorerUrl(txHash: string, chainId?: number): string {
   switch (chainId) {
     case OPTIMISM.chainId:


### PR DESCRIPTION
## **Summary of Changes**

Adds a view below the trade button (if there is a best option quote fetched) giving more transparency to the user on what contract the trade will be executed.

* Adds new convenience function to get a block explorer url for a contract

&nbsp;

## **Test Data or Screenshots**

<img width="529" alt="contract-view" src="https://user-images.githubusercontent.com/2104965/175970936-8a3c1ae0-de38-4efc-b259-966732aea03f.png">


&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
