### PR TITLE
Fix decimals in 0x quote

### DIFF
--- a/src/hooks/useBestQuote/index.ts
+++ b/src/hooks/useBestQuote/index.ts
@@ -219,6 +219,7 @@ export const useBestQuote = () => {
     const gasLimit0x = BigNumber.from(dexSwapOption?.gas ?? '0')
     const gasPrice0x = BigNumber.from(dexSwapOption?.gasPrice ?? '0')
     const gas0x = gasPrice0x.mul(gasLimit0x)
+    const sellTokenAmountInWei = toWei(sellTokenAmount, sellToken.decimals)
     const zeroExQuote: ZeroExQuote | null = dexSwapOption
       ? {
           type: QuoteType.zeroEx,
@@ -236,12 +237,12 @@ export const useBestQuote = () => {
             nativeTokenPrice
           ),
           priceImpact: parseFloat(dexSwapOption.estimatedPriceImpact ?? '5'),
-          setTokenAmount: BigNumber.from(
-            isIssuance ? dexSwapOption.buyAmount : sellTokenAmount
-          ),
-          inputOutputTokenAmount: BigNumber.from(
-            isIssuance ? sellTokenAmount : dexSwapOption.buyAmount
-          ),
+          setTokenAmount: isIssuance
+            ? BigNumber.from(dexSwapOption.buyAmount)
+            : sellTokenAmountInWei,
+          inputOutputTokenAmount: isIssuance
+            ? sellTokenAmountInWei
+            : BigNumber.from(dexSwapOption.buyAmount),
           // type specific properties
           chainId: dexSwapOption.chainId,
           data: dexSwapOption.data,


### PR DESCRIPTION
## **Summary of Changes**

Fixes issue where adding < 1 amounts for sell token. Issue was the wrong use of `BigNumber`. Using `toWei` fixes this.

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
