### PR TITLE
Fix selector width

### DIFF
--- a/src/components/trade/QuickTradeSelector.tsx
+++ b/src/components/trade/QuickTradeSelector.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { BigNumber } from 'ethers'
-import { colors, useColorStyles, useICColorMode } from 'styles/colors'
+import { colors, useColorStyles } from 'styles/colors'
 import { useNetwork } from 'wagmi'
 
 import { Box, Flex, Image, Input, Text } from '@chakra-ui/react'
@@ -185,6 +185,7 @@ const Selector = ({
     py='2'
     pl='3'
     pr='4'
+    shrink={0}
   >
     {!isNarrowVersion && (
       <Box mr='8px' w='24px'>


### PR DESCRIPTION
## **Summary of Changes**

Small fix to prevent the selector from breaking when choosing tokens with larger symbols like ETH2x-FLI.

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
