### PR TITLE
Hacky hack

### DIFF
--- a/src/components/trade/QuickTradeFormatter.ts
+++ b/src/components/trade/QuickTradeFormatter.ts
@@ -165,7 +165,7 @@ export function getTradeInfoDataFromEI(
   inputOutputTokenAmount: BigNumber,
   chainId: number = 1,
   isBuying: boolean,
-  navData: TradeInfoItem
+  navData: TradeInfoItem | null = null
 ): TradeInfoItem[] {
   const setTokenDecimals = isBuying ? buyToken.decimals : sellToken.decimals
   const inputTokenDecimals = sellToken.decimals
@@ -189,7 +189,7 @@ export function getTradeInfoDataFromEI(
       values: [maxPaymentFormatted],
     },
     { title: 'Network Fee', values: [`${networkFeeDisplay} ${networkToken}`] },
-    navData,
+    navData ?? { title: 'NavData', values: [''] },
     { title: 'Offered From', values: [offeredFrom] },
   ]
 }
@@ -218,7 +218,7 @@ export function getTradeInfoData0x(
   minOutput: BigNumber,
   sources: { name: string; proportion: string }[],
   chainId: number = 1,
-  navData: TradeInfoItem
+  navData: TradeInfoItem | null = null
 ): TradeInfoItem[] {
   const minReceive =
     displayFromWei(minOutput, 4) + ' ' + buyToken.symbol ?? '0.0'
@@ -238,7 +238,7 @@ export function getTradeInfoData0x(
       values: [minReceiveFormatted],
     },
     { title: 'Network Fee', values: [`${networkFeeDisplay} ${networkToken}`] },
-    navData,
+    navData ?? { title: 'NAV', values: [] },
     { title: 'Offered From', values: offeredFromSources },
   ]
 }


### PR DESCRIPTION
## **Summary of Changes**

It's def a timing issue. Most of the time when you have fetched the quote, the `nav` won't be there yet. This is a hacky attempt at solving this. Though there seems to be another issue with trade info component not updating on the change. Maybe it can't spot the change in the array's objects? 

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
