### PR TITLE
Add down chevron to selectors

### DIFF
--- a/src/components/trade/DirectIssuance.tsx
+++ b/src/components/trade/DirectIssuance.tsx
@@ -66,6 +66,7 @@ const DirectIssuance = ({
           isNarrowVersion: isNarrow,
           isSelectorDisabled: false,
           isReadOnly: false,
+          showMaxLabel: true,
         }}
         selectedToken={indexToken}
         selectedTokenAmount={indexTokenAmountFormatted}

--- a/src/components/trade/QuickTrade.tsx
+++ b/src/components/trade/QuickTrade.tsx
@@ -546,6 +546,7 @@ const QuickTrade = (props: QuickTradeProps) => {
             isNarrowVersion: isNarrow,
             isSelectorDisabled: false,
             isReadOnly: false,
+            showMaxLabel: true,
           }}
           selectedToken={sellToken}
           formattedFiat={sellTokenFiat}
@@ -574,6 +575,7 @@ const QuickTrade = (props: QuickTradeProps) => {
             isNarrowVersion: isNarrow,
             isSelectorDisabled: false,
             isReadOnly: true,
+            showMaxLabel: false,
           }}
           selectedToken={buyToken}
           selectedTokenAmount={buyTokenAmountFormatted}

--- a/src/components/trade/QuickTradeSelector.tsx
+++ b/src/components/trade/QuickTradeSelector.tsx
@@ -20,6 +20,7 @@ interface InputSelectorConfig {
   isInputDisabled?: boolean
   isSelectorDisabled?: boolean
   isReadOnly?: boolean
+  showMaxLabel: boolean
 }
 
 const QuickTradeSelector = (props: {
@@ -141,7 +142,11 @@ const QuickTradeSelector = (props: {
           selectedTokenSymbol={selectedTokenSymbol}
         />
       </Flex>
-      <Balance balance={tokenBalance} onClick={onClickBalance} />
+      <Balance
+        balance={tokenBalance}
+        onClick={onClickBalance}
+        showMaxLabel={config.showMaxLabel}
+      />
     </Flex>
   )
 }
@@ -149,19 +154,30 @@ const QuickTradeSelector = (props: {
 type BalanceProps = {
   balance: string
   onClick: () => void
+  showMaxLabel: boolean
 }
 
-const Balance = ({ balance, onClick }: BalanceProps) => (
-  <Text
-    align='left'
-    fontSize='12px'
-    fontWeight='400'
-    mt='5px'
-    onClick={onClick}
-    cursor='pointer'
-  >
-    Balance: {balance}
-  </Text>
+const Balance = ({ balance, onClick, showMaxLabel }: BalanceProps) => (
+  <Flex align='left' cursor='pointer' onClick={onClick} mt='8px'>
+    <Text fontSize='12px' fontWeight='400'>
+      Balance: {balance}
+    </Text>
+    {showMaxLabel === true && (
+      <Flex
+        align='center'
+        bg={colors.icBlue10}
+        borderRadius='12px'
+        justify='center'
+        py='2px'
+        px='6px'
+        ml='4px'
+      >
+        <Text color={colors.icBlue2} fontSize='10px'>
+          MAX
+        </Text>
+      </Flex>
+    )}
+  </Flex>
 )
 
 type SelectorProps = {


### PR DESCRIPTION
## **Summary of Changes**

Adds a down chevron icon to the selectors of the trade component to make it even more obvious that this can be selected.

&nbsp;

## **Test Data or Screenshots**
<img width="538" alt="chevron" src="https://user-images.githubusercontent.com/2104965/187307099-be692c90-db42-481e-bd6d-3168d0058c9b.png">

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
