### PR TITLE
Fix approval state for redeeming

### DIFF
--- a/src/components/trade/FlashMint.tsx
+++ b/src/components/trade/FlashMint.tsx
@@ -195,9 +195,11 @@ const FlashMint = (props: QuickTradeProps) => {
       return 'Approving...'
     }
 
-    const isNativeToken =
-      inputOutputToken.symbol === getNativeToken(chainId)?.symbol ?? ''
-    if (!isNativeToken && !isApproved()) {
+    // For redeeming it will always be an index, so approval state should be checked
+    const isNativeCurrency = isMinting
+      ? inputOutputToken.symbol === getNativeToken(chainId)?.symbol ?? ''
+      : false
+    if (!isNativeCurrency && !isApproved()) {
       return 'Approve Tokens'
     }
 


### PR DESCRIPTION
We only need to check if it's a native currency when minting. For redeeming we'll always have to check the approval state.

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
