### PR TITLE
Fix 2x FLIs on mainnet

### DIFF
--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -569,8 +569,13 @@ export const indexNamesOptimism = indexNames.filter(
 
 // FlashMint specific lists
 export const flashMintIndexesMainnet = indexNames.filter(
-  (index) => index.address && index.symbol !== IndexToken.symbol
+  (index) =>
+    index.address &&
+    index.symbol !== Bitcoin2xFlexibleLeverageIndex.symbol &&
+    index.symbol !== Ethereum2xFlexibleLeverageIndex.symbol &&
+    index.symbol !== IndexToken.symbol
 )
+
 export const flashMintIndexesPolygon = indexNames.filter(
   (index) =>
     index.polygonAddress &&

--- a/src/hooks/useBestQuote/flashMintZeroEx.ts
+++ b/src/hooks/useBestQuote/flashMintZeroEx.ts
@@ -3,7 +3,13 @@ import { JsonRpcProvider } from '@ethersproject/providers'
 import { getFlashMintZeroExQuote, ZeroExApi } from '@indexcoop/flash-mint-sdk'
 
 import { MAINNET } from 'constants/chains'
-import { icETHIndex, IndexToken, Token } from 'constants/tokens'
+import {
+  Bitcoin2xFlexibleLeverageIndex,
+  Ethereum2xFlexibleLeverageIndex,
+  icETHIndex,
+  IndexToken,
+  Token,
+} from 'constants/tokens'
 import { getFullCostsInUsd, getGasCostsInUsd } from 'utils/costs'
 import { getFlashMintZeroExGasEstimate } from 'utils/flashMintZeroExGasEstimate'
 
@@ -13,6 +19,18 @@ export function isEligibleTradePairZeroEx(
   inputToken: Token,
   outputToken: Token
 ): boolean {
+  if (
+    inputToken.symbol === Bitcoin2xFlexibleLeverageIndex.symbol ||
+    outputToken.symbol === Bitcoin2xFlexibleLeverageIndex.symbol
+  )
+    return false
+
+  if (
+    inputToken.symbol === Ethereum2xFlexibleLeverageIndex.symbol ||
+    outputToken.symbol === Ethereum2xFlexibleLeverageIndex.symbol
+  )
+    return false
+
   if (
     inputToken.symbol === icETHIndex.symbol ||
     outputToken.symbol === icETHIndex.symbol

--- a/src/hooks/useBestQuote/index.test.ts
+++ b/src/hooks/useBestQuote/index.test.ts
@@ -1,8 +1,10 @@
 import { BigNumber } from 'ethers'
 
 import {
+  Bitcoin2xFlexibleLeverageIndex,
   DAI,
   ETH,
+  Ethereum2xFlexibleLeverageIndex,
   Ethereum2xFLIP,
   icETHIndex,
   IMaticFLIP,
@@ -282,6 +284,33 @@ describe('isEligibleTradePairZeroEx()', () => {
     // Reenabled
     const isEligibleJpg = isEligibleTradePairZeroEx(inputToken, JPGIndex)
     expect(isEligibleJpg).toEqual(true)
+    // Won't work with ZeroEx, so shouldn't be eligible
+    const isEligibleBtc2xFli = isEligibleTradePairZeroEx(
+      inputToken,
+      Bitcoin2xFlexibleLeverageIndex
+    )
+    expect(isEligibleBtc2xFli).toEqual(false)
+    const isEligibleEth2xFli = isEligibleTradePairZeroEx(
+      inputToken,
+      Ethereum2xFlexibleLeverageIndex
+    )
+    expect(isEligibleEth2xFli).toEqual(false)
+  })
+
+  test('mainnet FLIs are not be eligible for ZeroEx', async () => {
+    const inputToken = ETH
+
+    // Won't work with the ZeroEx contract, so shouldn't be eligible
+    const isEligibleBtc2xFli = isEligibleTradePairZeroEx(
+      inputToken,
+      Bitcoin2xFlexibleLeverageIndex
+    )
+    expect(isEligibleBtc2xFli).toEqual(false)
+    const isEligibleEth2xFli = isEligibleTradePairZeroEx(
+      inputToken,
+      Ethereum2xFlexibleLeverageIndex
+    )
+    expect(isEligibleEth2xFli).toEqual(false)
   })
 })
 


### PR DESCRIPTION
## **Summary of Changes**

* Fixes tests for 2x FLIs eligibility for trading (won't work for zero ex flash mint contract)
* Hide indices for flash minting for now

&nbsp;


###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
