### PR TITLE
Add dollar values to FlashMint

### DIFF
--- a/src/components/trade/flashmint/DirectIssuance.tsx
+++ b/src/components/trade/flashmint/DirectIssuance.tsx
@@ -11,6 +11,7 @@ type DirectIssuanceProps = {
   indexToken: Token
   indexTokenList: Token[]
   indexTokenAmountFormatted: string | undefined
+  indexTokenFiatFormatted: string
   inputOutputToken: Token
   inputOutputTokenAmountFormatted: string
   inputOutputTokenBalanceFormatted: string
@@ -28,6 +29,7 @@ const DirectIssuance = ({
   indexToken,
   indexTokenList,
   indexTokenAmountFormatted,
+  indexTokenFiatFormatted,
   inputOutputToken,
   inputOutputTokenAmountFormatted,
   inputOutputTokenBalanceFormatted,
@@ -71,7 +73,7 @@ const DirectIssuance = ({
         }}
         selectedToken={indexToken}
         selectedTokenAmount={indexTokenAmountFormatted}
-        formattedFiat=''
+        formattedFiat={indexTokenFiatFormatted}
         priceImpact={priceImpact}
         tokenList={indexTokenList}
         onChangeInput={onChangeBuyTokenAmount}

--- a/src/components/trade/flashmint/DirectIssuance.tsx
+++ b/src/components/trade/flashmint/DirectIssuance.tsx
@@ -15,6 +15,7 @@ type DirectIssuanceProps = {
   inputOutputToken: Token
   inputOutputTokenAmountFormatted: string
   inputOutputTokenBalanceFormatted: string
+  inputOutputTokenFiatFormatted: string
   isDarkMode: boolean
   isIssue: boolean
   isNarrow: boolean
@@ -33,6 +34,7 @@ const DirectIssuance = ({
   inputOutputToken,
   inputOutputTokenAmountFormatted,
   inputOutputTokenBalanceFormatted,
+  inputOutputTokenFiatFormatted,
   isDarkMode,
   isIssue,
   isNarrow,
@@ -105,9 +107,12 @@ const DirectIssuance = ({
           />
           <ChevronDownIcon ml={1} w={6} h={6} color={colors.icGray4} />
         </Flex>
-        <Text fontWeight='600' marginLeft='16px'>
-          {inputOutputTokenAmountFormatted}
-        </Text>
+        <Flex direction='column' marginLeft='16px'>
+          <Text fontWeight='600'>{inputOutputTokenAmountFormatted}</Text>
+          <Text fontSize='12px' textColor={colorStyles(isDarkMode).text3}>
+            {inputOutputTokenFiatFormatted}
+          </Text>
+        </Flex>
       </Flex>
       <Text marginTop='8px' fontSize='12px' fontWeight='400'>
         {inputOutputToken.symbol} Balance: {inputOutputTokenBalanceFormatted}

--- a/src/components/trade/flashmint/index.tsx
+++ b/src/components/trade/flashmint/index.tsx
@@ -33,6 +33,7 @@ import { getNativeToken, isNotTradableToken } from 'utils/tokens'
 import { TradeButtonContainer } from '../_shared/footer'
 import {
   formattedBalance,
+  formattedFiat,
   getHasInsufficientFunds,
 } from '../_shared/QuickTradeFormatter'
 import {
@@ -71,8 +72,10 @@ const FlashMint = (props: QuickTradeProps) => {
   const {
     buyToken: indexToken,
     buyTokenList: indexTokenList,
+    buyTokenPrice: indexTokenPrice,
     sellToken: inputOutputToken,
     sellTokenList: inputOutputTokenList,
+    sellTokenPrice: inputOutputPrice,
     changeBuyToken: changeIndexToken,
     changeSellToken: changeInputOutputToken,
   } = useTradeTokenLists(props.singleToken, true)
@@ -322,6 +325,11 @@ const FlashMint = (props: QuickTradeProps) => {
     getBalance(inputOutputToken.symbol)
   )
 
+  const indexTokenFiatFormatted = formattedFiat(
+    parseFloat(indexTokenAmount),
+    indexTokenPrice
+  )
+
   const shouldShowOverride: boolean = txWouldFailZeroEx || txWouldFailLeveraged
 
   return (
@@ -330,6 +338,7 @@ const FlashMint = (props: QuickTradeProps) => {
         indexToken={indexToken}
         indexTokenList={indexTokenList}
         indexTokenAmountFormatted={indexTokenAmountFormatted}
+        indexTokenFiatFormatted={indexTokenFiatFormatted}
         inputOutputToken={inputOutputToken}
         inputOutputTokenAmountFormatted={inputOutputTokenAmountFormatted}
         inputOutputTokenBalanceFormatted={inputOutputTokenBalanceFormatted}

--- a/src/components/trade/flashmint/index.tsx
+++ b/src/components/trade/flashmint/index.tsx
@@ -26,7 +26,7 @@ import { useTradeFlashMintZeroEx } from 'hooks/useTradeFlashMintZeroEx'
 import { useTradeTokenLists } from 'hooks/useTradeTokenLists'
 import { useWallet } from 'hooks/useWallet'
 import { useSlippage } from 'providers/Slippage'
-import { isValidTokenInput, toWei } from 'utils'
+import { displayFromWei, isValidTokenInput, toWei } from 'utils'
 import { getBlockExplorerContractUrl } from 'utils/blockExplorer'
 import { getNativeToken, isNotTradableToken } from 'utils/tokens'
 
@@ -329,6 +329,13 @@ const FlashMint = (props: QuickTradeProps) => {
     parseFloat(indexTokenAmount),
     indexTokenPrice
   )
+  const inputOutputTokenFiatFormatted = formattedFiat(
+    parseFloat(
+      displayFromWei(inputOutputTokenAmount, 2, inputOutputToken.decimals) ??
+        '0'
+    ),
+    inputOutputPrice
+  )
 
   const shouldShowOverride: boolean = txWouldFailZeroEx || txWouldFailLeveraged
 
@@ -342,6 +349,7 @@ const FlashMint = (props: QuickTradeProps) => {
         inputOutputToken={inputOutputToken}
         inputOutputTokenAmountFormatted={inputOutputTokenAmountFormatted}
         inputOutputTokenBalanceFormatted={inputOutputTokenBalanceFormatted}
+        inputOutputTokenFiatFormatted={inputOutputTokenFiatFormatted}
         isDarkMode={isDarkMode}
         isIssue={isMinting}
         isNarrow={isNarrow}


### PR DESCRIPTION
## **Summary of Changes**

Adds dollar values for the index and input/ouput token in FlashMint, so users can better comprehend the values they are getting.

&nbsp;

## **Test Data or Screenshots**

<img width="553" alt="$" src="https://user-images.githubusercontent.com/2104965/197813093-4708c827-18af-4eab-852e-672a42c38847.png">


&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
