### PR TITLE
Deprecate MNYe, DATA, GMI, FLI-P

### DIFF
--- a/src/components/trade/flashmint/DirectIssuance.tsx
+++ b/src/components/trade/flashmint/DirectIssuance.tsx
@@ -18,6 +18,7 @@ type DirectIssuanceProps = {
   inputOutputTokenFiatFormatted: string
   isDarkMode: boolean
   isIssue: boolean
+  isMintable: boolean
   isNarrow: boolean
   onChangeBuyTokenAmount: (token: Token, input: string) => void
   onSelectIndexToken: () => void
@@ -37,6 +38,7 @@ const DirectIssuance = ({
   inputOutputTokenFiatFormatted,
   isDarkMode,
   isIssue,
+  isMintable,
   isNarrow,
   onChangeBuyTokenAmount,
   onSelectIndexToken,
@@ -59,6 +61,17 @@ const DirectIssuance = ({
         />
       </Flex>
     </Flex>
+    <Flex>
+      {!isMintable && (
+        <Text
+          color={isDarkMode ? colors.icBlue8 : colors.icBlue6}
+          fontSize={'12px'}
+          m='2'
+        >
+          This token is deprecated and available for redemption only.
+        </Text>
+      )}
+    </Flex>
     <Box
       borderColor={isDarkMode ? colors.icWhite : colors.black}
       paddingTop='16px'
@@ -67,11 +80,11 @@ const DirectIssuance = ({
         title={''}
         config={{
           isDarkMode,
-          isInputDisabled: false,
+          isInputDisabled: isIssue && !isMintable,
           isNarrowVersion: isNarrow,
-          isSelectorDisabled: false,
-          isReadOnly: false,
-          showMaxLabel: true,
+          isSelectorDisabled: isIssue && !isMintable,
+          isReadOnly: isIssue && !isMintable,
+          showMaxLabel: isIssue && isMintable,
         }}
         selectedToken={indexToken}
         selectedTokenAmount={indexTokenAmountFormatted}

--- a/src/components/trade/flashmint/index.tsx
+++ b/src/components/trade/flashmint/index.tsx
@@ -28,7 +28,11 @@ import { useWallet } from 'hooks/useWallet'
 import { useSlippage } from 'providers/Slippage'
 import { displayFromWei, isValidTokenInput, toWei } from 'utils'
 import { getBlockExplorerContractUrl } from 'utils/blockExplorer'
-import { getNativeToken, isNotTradableToken } from 'utils/tokens'
+import {
+  getNativeToken,
+  isNotTradableToken,
+  isTokenMintable,
+} from 'utils/tokens'
 
 import { TradeButtonContainer } from '../_shared/footer'
 import {
@@ -85,6 +89,7 @@ const FlashMint = (props: QuickTradeProps) => {
   const [indexTokenAmountFormatted, setIndexTokenAmountFormatted] =
     useState('0.0')
   const [indexTokenAmount, setIndexTokenAmount] = useState('0')
+  const [isMintable, setIsMintable] = useState(true)
   const [isMinting, setIsMinting] = useState(true)
   const [override, setOverride] = useState(false)
 
@@ -129,6 +134,11 @@ const FlashMint = (props: QuickTradeProps) => {
     indexTokenAmountWei,
     getBalance(indexToken.symbol)
   )
+
+  useEffect(() => {
+    const isMintable = isTokenMintable(indexToken, chainId)
+    setIsMintable(isMintable)
+  }, [chainId, indexToken])
 
   useEffect(() => {
     const indexTokenAmountWei = toWei(indexTokenAmount, indexToken.decimals)
@@ -352,6 +362,7 @@ const FlashMint = (props: QuickTradeProps) => {
         inputOutputTokenFiatFormatted={inputOutputTokenFiatFormatted}
         isDarkMode={isDarkMode}
         isIssue={isMinting}
+        isMintable={isMintable}
         isNarrow={isNarrow}
         onChangeBuyTokenAmount={onChangeIndexTokenAmount}
         onSelectIndexToken={() => {

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -568,7 +568,18 @@ export const indexNamesOptimism = indexNames.filter(
 )
 
 // FlashMint specific lists
-export const flashMintIndexesMainnet = indexNames.filter(
+export const flashMintIndexesMainnetMint = indexNames.filter(
+  (index) =>
+    index.address &&
+    index.symbol !== Bitcoin2xFlexibleLeverageIndex.symbol &&
+    index.symbol !== Ethereum2xFlexibleLeverageIndex.symbol &&
+    index.symbol !== IndexToken.symbol &&
+    // DATA and GMI are now deprecated
+    index.symbol !== DataIndex.symbol &&
+    index.symbol !== GmiIndex.symbol
+)
+
+export const flashMintIndexesMainnetRedeem = indexNames.filter(
   (index) =>
     index.address &&
     index.symbol !== Bitcoin2xFlexibleLeverageIndex.symbol &&

--- a/src/hooks/useTradeTokenLists.test.ts
+++ b/src/hooks/useTradeTokenLists.test.ts
@@ -1,0 +1,62 @@
+import {
+  DefiPulseIndex,
+  flashMintIndexesMainnetMint,
+  flashMintIndexesMainnetRedeem,
+  flashMintIndexesPolygon,
+  indexNamesMainnet,
+  indexNamesOptimism,
+  indexNamesPolygon,
+} from 'constants/tokens'
+
+import { getTokenListByChain } from './useTradeTokenLists'
+
+describe('getTokenListByChain()', () => {
+  test('returns single token for single token', async () => {
+    const chainId = 1
+    const isFlashMint = false
+    const singleToken = DefiPulseIndex
+    const list = getTokenListByChain(chainId, isFlashMint, singleToken)
+    expect(list.length).toBe(1)
+    expect(list[0]).toBe(DefiPulseIndex)
+  })
+
+  test('returns regular list for swap on mainnet', async () => {
+    const chainId = 1
+    const isFlashMint = false
+    const singleToken = undefined
+    const list = getTokenListByChain(chainId, isFlashMint, singleToken)
+    expect(list).toEqual(indexNamesMainnet)
+  })
+
+  test('returns redeem list for flash mint on mainnet', async () => {
+    const chainId = 1
+    const isFlashMint = true
+    const singleToken = undefined
+    const list = getTokenListByChain(chainId, isFlashMint, singleToken)
+    expect(list).toEqual(flashMintIndexesMainnetRedeem)
+  })
+
+  test('returns list for optimism', async () => {
+    const chainId = 10
+    const isFlashMint = true
+    const singleToken = undefined
+    const list = getTokenListByChain(chainId, isFlashMint, singleToken)
+    expect(list).toEqual(indexNamesOptimism)
+  })
+
+  test('returns regular list for swap on polygon', async () => {
+    const chainId = 137
+    const isFlashMint = false
+    const singleToken = undefined
+    const list = getTokenListByChain(chainId, isFlashMint, singleToken)
+    expect(list).toEqual(indexNamesPolygon)
+  })
+
+  test('returns specific list for flash mint on polygon', async () => {
+    const chainId = 137
+    const isFlashMint = true
+    const singleToken = undefined
+    const list = getTokenListByChain(chainId, isFlashMint, singleToken)
+    expect(list).toEqual(flashMintIndexesPolygon)
+  })
+})

--- a/src/hooks/useTradeTokenLists.ts
+++ b/src/hooks/useTradeTokenLists.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { MAINNET, OPTIMISM, POLYGON } from 'constants/chains'
 import {
   ETH,
-  flashMintIndexesMainnet,
+  flashMintIndexesMainnetRedeem,
   flashMintIndexesPolygon,
   icETHIndex,
   indexNamesMainnet,
@@ -170,16 +170,17 @@ const getCurrencyTokensForToken = (token: Token, chainId: number) => {
  * Get the list of currency tokens for the selected chain
  * @returns Token[] list of tokens
  */
-const getTokenListByChain = (
+export const getTokenListByChain = (
   chainId: number | undefined = MAINNET.chainId,
   isFlashMint: boolean,
   singleToken: Token | undefined
 ) => {
   if (singleToken) return [singleToken]
-  if (chainId === POLYGON.chainId)
+  if (chainId === POLYGON.chainId) {
     return isFlashMint ? flashMintIndexesPolygon : indexNamesPolygon
+  }
   if (chainId === OPTIMISM.chainId) return indexNamesOptimism
-  return isFlashMint ? flashMintIndexesMainnet : indexNamesMainnet
+  return isFlashMint ? flashMintIndexesMainnetRedeem : indexNamesMainnet
 }
 
 /**

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -1,7 +1,8 @@
 import { MAINNET, OPTIMISM, POLYGON } from 'constants/chains'
 import {
   ETH,
-  flashMintIndexesMainnet,
+  flashMintIndexesMainnetMint,
+  flashMintIndexesMainnetRedeem,
   flashMintIndexesPolygon,
   indexNamesMainnet,
   indexNamesOptimism,
@@ -115,7 +116,7 @@ export function isTokenAvailableForFlashMint(
   switch (chainId) {
     case MAINNET.chainId:
       return (
-        flashMintIndexesMainnet.filter((t) => t.symbol === token.symbol)
+        flashMintIndexesMainnetRedeem.filter((t) => t.symbol === token.symbol)
           .length > 0
       )
     case OPTIMISM.chainId:
@@ -127,6 +128,25 @@ export function isTokenAvailableForFlashMint(
         flashMintIndexesPolygon.filter((t) => t.symbol === token.symbol)
           .length > 0
       )
+    default:
+      return false
+  }
+}
+
+export function isTokenMintable(
+  token: Token,
+  chainId: number | undefined
+): boolean {
+  switch (chainId) {
+    case MAINNET.chainId:
+      return (
+        flashMintIndexesMainnetMint.filter((t) => t.symbol === token.symbol)
+          .length > 0
+      )
+    case OPTIMISM.chainId:
+      return false
+    case POLYGON.chainId:
+      return false
     default:
       return false
   }


### PR DESCRIPTION
## **Summary of Changes**

Update so deprecated indices are no longer mintable via FlashMint (redeem only).

&nbsp;

## **Test Data or Screenshots**

<img width="546" alt="redeem" src="https://user-images.githubusercontent.com/2104965/198393831-feb248dc-28e3-47f9-b851-7b0671b09b2b.png">


&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
