### PR TITLE
Update swap to prevent minting of deprecated tokens

### DIFF
--- a/src/components/trade/swap/index.tsx
+++ b/src/components/trade/swap/index.tsx
@@ -22,7 +22,12 @@ import { useSlippage } from 'providers/Slippage'
 import { isValidTokenInput, toWei } from 'utils'
 import { getBlockExplorerContractUrl } from 'utils/blockExplorer'
 import { getZeroExRouterAddress } from 'utils/contracts'
-import { getNativeToken, isNotTradableToken, isPerpToken } from 'utils/tokens'
+import {
+  getNativeToken,
+  isNotTradableToken,
+  isPerpToken,
+  isTokenMintable,
+} from 'utils/tokens'
 
 import { TradeButtonContainer } from '../_shared/footer'
 import {
@@ -428,6 +433,7 @@ const QuickTrade = (props: QuickTradeProps) => {
   ])
 
   const betterQuoteState = getBetterQuoteState()
+  const tokenIsMintable = isTokenMintable(buyToken, chainId)
 
   return (
     <Box>
@@ -436,11 +442,13 @@ const QuickTrade = (props: QuickTradeProps) => {
           title='From'
           config={{
             isDarkMode,
-            isInputDisabled: isNotTradableToken(props.singleToken, chainId),
+            isInputDisabled:
+              isNotTradableToken(props.singleToken, chainId) ||
+              !tokenIsMintable,
             isNarrowVersion: isNarrow,
             isSelectorDisabled: false,
-            isReadOnly: false,
-            showMaxLabel: true,
+            isReadOnly: !tokenIsMintable,
+            showMaxLabel: !tokenIsMintable,
           }}
           selectedToken={sellToken}
           formattedFiat={sellTokenFiat}

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -140,13 +140,21 @@ export function isTokenMintable(
   switch (chainId) {
     case MAINNET.chainId:
       return (
+        mainnetCurrencyTokens.filter((t) => t.symbol === token.symbol).length >
+          0 ||
         flashMintIndexesMainnetMint.filter((t) => t.symbol === token.symbol)
           .length > 0
       )
     case OPTIMISM.chainId:
-      return false
+      return (
+        optimismCurrencyTokens.filter((t) => t.symbol === token.symbol).length >
+        0
+      )
     case POLYGON.chainId:
-      return false
+      return (
+        polygonCurrencyTokens.filter((t) => t.symbol === token.symbol).length >
+        0
+      )
     default:
       return false
   }


### PR DESCRIPTION
## **Summary of Changes**

Updates `Swap` to prevent minting of deprecated tokens (now redeem only). Leverages existing `tokenIsMintable` function.

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
