### PR TITLE
remove alert warning because theres no longer a swap option

### DIFF
--- a/src/components/trade/flashmint/index.tsx
+++ b/src/components/trade/flashmint/index.tsx
@@ -375,17 +375,7 @@ const FlashMint = (props: QuickTradeProps) => {
         isOpen={isIndexTokenModalOpen}
         onClose={onCloseIndexTokenModal}
         onSelectedToken={(tokenSymbol) => {
-          if (
-            tokenSymbol === 'ETH2X-FLI-P' ||
-            tokenSymbol === 'BTC2x-FLI-P' ||
-            tokenSymbol === 'MATIC2x-FLI-P'
-          ) {
-            alert(
-              `${tokenSymbol} is currently sell only. Please use Swap instead of FlashMint.`
-            )
-          } else {
-            changeIndexToken(tokenSymbol)
-          }
+          changeIndexToken(tokenSymbol)
           onCloseIndexTokenModal()
         }}
         items={indexTokenItems}


### PR DESCRIPTION
## **Summary of Changes**

Removes the alert for 2x-FLI-Ps telling user to swap. 


## **Test Data or Screenshots**

<img width="454" alt="legacyproducts_indexcoop_com_says_and_Index_Coop_Legacy_Products___Redeem_Tokens" src="https://user-images.githubusercontent.com/1253142/210709161-6a0b9df8-2777-4dcf-921b-900505d23a5a.png">


###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
