### PR TITLE
Reactivate 2xFLI's for redeeming

### DIFF
--- a/src/components/trade/_shared/SelectTokenModal.tsx
+++ b/src/components/trade/_shared/SelectTokenModal.tsx
@@ -136,10 +136,10 @@ const TokenItem = ({
 
 function isSellOnly(token: Token): boolean {
   switch (token.symbol) {
-    case Bitcoin2xFLIP.symbol:
-    case Ethereum2xFLIP.symbol:
-    case Matic2xFLIP.symbol:
-      return true
+    // case Bitcoin2xFLIP.symbol:
+    // case Ethereum2xFLIP.symbol:
+    // case Matic2xFLIP.symbol:
+    //   return true
     default:
       return false
   }

--- a/src/components/trade/flashmint/index.tsx
+++ b/src/components/trade/flashmint/index.tsx
@@ -375,17 +375,17 @@ const FlashMint = (props: QuickTradeProps) => {
         isOpen={isIndexTokenModalOpen}
         onClose={onCloseIndexTokenModal}
         onSelectedToken={(tokenSymbol) => {
-          if (
-            tokenSymbol === 'ETH2X-FLI-P' ||
-            tokenSymbol === 'BTC2x-FLI-P' ||
-            tokenSymbol === 'MATIC2x-FLI-P'
-          ) {
-            alert(
-              `${tokenSymbol} is currently sell only. Please use Swap instead of FlashMint.`
-            )
-          } else {
-            changeIndexToken(tokenSymbol)
-          }
+          // if (
+          //   // tokenSymbol === 'ETH2X-FLI-P' ||
+          //   // tokenSymbol === 'BTC2x-FLI-P' ||
+          //   // tokenSymbol === 'MATIC2x-FLI-P'
+          // ) {
+          //   alert(
+          //     `${tokenSymbol} is currently sell only. Please use Swap instead of FlashMint.`
+          //   )
+          // } else {
+          changeIndexToken(tokenSymbol)
+          // }
           onCloseIndexTokenModal()
         }}
         items={indexTokenItems}

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -546,13 +546,13 @@ export const deprecatedIndices = [
 
 // Deprecated/rebalanced indicies will not work with FlashMintLeveraged any longer
 export const eligibleLeveragedExchangeIssuanceTokens = [
-  // Bitcoin2xFLIP,
-  // Ethereum2xFLIP,
+  Bitcoin2xFLIP,
+  Ethereum2xFLIP,
   IBitcoinFLIP,
   icETHIndex,
   IEthereumFLIP,
   IMaticFLIP,
-  // Matic2xFLIP,
+  Matic2xFLIP,
 ]
 
 const isDevEnv =


### PR DESCRIPTION
### Current Status

iETHFLIP: ✅
iBTCFLIP: too many components error
iMATICFLIP: ✅
ETH2xFLIP: errors for some 0x API calls but still shows the correct quote
BTC2xFLIP: errors for some 0x API calls but still shows the correct quote
MATIC2xFLIP: too many components error



###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
