### PR TITLE
Add slippage mapping

### DIFF
--- a/src/components/trade/flashmint/index.tsx
+++ b/src/components/trade/flashmint/index.tsx
@@ -17,6 +17,7 @@ import { useSlippage } from 'providers/Slippage'
 import { displayFromWei, isValidTokenInput, toWei } from 'utils'
 import { getBlockExplorerContractUrl } from 'utils/blockExplorer'
 import { getContractForQuote, getQuoteAmount } from 'utils/flashMint/quotes'
+import { selectSlippage } from 'utils/slippage'
 import { getNativeToken, isNotTradableToken } from 'utils/tokens'
 
 import { TradeButtonContainer } from '../_shared/footer'
@@ -105,9 +106,9 @@ const FlashMint = (props: QuickTradeProps) => {
   )
 
   const getSlippage = useCallback(() => {
-    // Temporarily use at least 2% slippage for FlashMint
-    return slippage > 2 ? slippage : 2
-  }, [slippage])
+    const useSlippage = selectSlippage(slippage, indexToken.symbol)
+    return useSlippage
+  }, [indexToken, slippage])
 
   useEffect(() => {
     const contractAddress = getContractForQuote(quoteResult, chainId)

--- a/src/constants/slippage.ts
+++ b/src/constants/slippage.ts
@@ -1,0 +1,9 @@
+import { icETHIndex, WSETH2 } from './tokens'
+
+// Slippage default hard coded to 1%
+export const slippageDefault = 1
+
+export const slippageMap = new Map([
+  [icETHIndex.symbol, 2],
+  [WSETH2.symbol, 0.1],
+])

--- a/src/providers/Slippage/index.tsx
+++ b/src/providers/Slippage/index.tsx
@@ -1,7 +1,6 @@
 import { createContext, useContext, useState } from 'react'
 
-// Slippage default hard coded to 1%
-export const slippageDefault = 1
+import { slippageDefault } from 'constants/slippage'
 
 interface Context {
   isAuto: boolean

--- a/src/utils/slippage.test.ts
+++ b/src/utils/slippage.test.ts
@@ -1,32 +1,32 @@
 import { slippageMap } from 'constants/slippage'
 import { icETHIndex, WSETH2 } from 'constants/tokens'
 
-import { getSlippageModification, selectSlippage } from './slippage'
+import { getSlippageOverrideOrNull, selectSlippage } from './slippage'
 
-describe('getSlippageModification()', () => {
+describe('getSlippageOverrideOrNull()', () => {
   it('returns null for unaltered slippage', () => {
     const symbol = 'MVI'
-    const slippage = getSlippageModification(symbol)
-    expect(slippage).toBe(null)
+    const slippageOverride = getSlippageOverrideOrNull(symbol)
+    expect(slippageOverride).toBe(null)
   })
 
   it('returns correct slippage for icETH', () => {
     const symbol = icETHIndex.symbol
-    const slippage = getSlippageModification(symbol)
-    expect(slippage).toBe(slippageMap.get(symbol))
+    const slippageOverride = getSlippageOverrideOrNull(symbol)
+    expect(slippageOverride).toBe(slippageMap.get(symbol))
   })
 
   it('returns correct slippage for wsETH2', () => {
     const symbol = WSETH2.symbol
-    const slippage = getSlippageModification(symbol)
-    expect(slippage).toBe(slippageMap.get(symbol))
+    const slippageOverride = getSlippageOverrideOrNull(symbol)
+    expect(slippageOverride).toBe(slippageMap.get(symbol))
   })
 })
 
 describe('selectSlippage()', () => {
   it('returns given slippage for undefined token', () => {
     const symbol = 'MVI'
-    const slippageModified = getSlippageModification(symbol)
+    const slippageModified = getSlippageOverrideOrNull(symbol)
     const result = selectSlippage(1, symbol)
     expect(slippageModified).toBeNull()
     expect(result).toBe(1)
@@ -34,7 +34,7 @@ describe('selectSlippage()', () => {
 
   it('returns correct slippage for token in mapping (bigger value)', () => {
     const symbol = icETHIndex.symbol
-    const slippageModified = getSlippageModification(symbol)
+    const slippageModified = getSlippageOverrideOrNull(symbol)
     const result = selectSlippage(1, symbol)
     expect(slippageModified).toBe(slippageMap.get(symbol))
     expect(result).toBe(slippageModified)
@@ -42,7 +42,7 @@ describe('selectSlippage()', () => {
 
   it('returns correct slippage for token in mapping (smaller value)', () => {
     const symbol = WSETH2.symbol
-    const slippageModified = getSlippageModification(symbol)
+    const slippageModified = getSlippageOverrideOrNull(symbol)
     const result = selectSlippage(1, symbol)
     expect(slippageModified).toBe(slippageMap.get(symbol))
     expect(result).toBe(slippageModified)
@@ -51,7 +51,7 @@ describe('selectSlippage()', () => {
   it('returns correct slippage when default was modified by user', () => {
     const expectedSlippaged = 2
     const symbol = WSETH2.symbol
-    const slippageModified = getSlippageModification(symbol)
+    const slippageModified = getSlippageOverrideOrNull(symbol)
     const result = selectSlippage(expectedSlippaged, symbol)
     expect(slippageModified).toBe(slippageMap.get(symbol))
     expect(result).toBe(expectedSlippaged)

--- a/src/utils/slippage.test.ts
+++ b/src/utils/slippage.test.ts
@@ -1,7 +1,7 @@
 import { slippageMap } from 'constants/slippage'
 import { icETHIndex, WSETH2 } from 'constants/tokens'
 
-import { getSlippageModification } from './slippage'
+import { getSlippageModification, selectSlippage } from './slippage'
 
 describe('getSlippageModification()', () => {
   it('returns null for unaltered slippage', () => {
@@ -20,5 +20,40 @@ describe('getSlippageModification()', () => {
     const symbol = WSETH2.symbol
     const slippage = getSlippageModification(symbol)
     expect(slippage).toBe(slippageMap.get(symbol))
+  })
+})
+
+describe('selectSlippage()', () => {
+  it('returns given slippage for undefined token', () => {
+    const symbol = 'MVI'
+    const slippageModified = getSlippageModification(symbol)
+    const result = selectSlippage(1, symbol)
+    expect(slippageModified).toBeNull()
+    expect(result).toBe(1)
+  })
+
+  it('returns correct slippage for token in mapping (bigger value)', () => {
+    const symbol = icETHIndex.symbol
+    const slippageModified = getSlippageModification(symbol)
+    const result = selectSlippage(1, symbol)
+    expect(slippageModified).toBe(slippageMap.get(symbol))
+    expect(result).toBe(slippageModified)
+  })
+
+  it('returns correct slippage for token in mapping (smaller value)', () => {
+    const symbol = WSETH2.symbol
+    const slippageModified = getSlippageModification(symbol)
+    const result = selectSlippage(1, symbol)
+    expect(slippageModified).toBe(slippageMap.get(symbol))
+    expect(result).toBe(slippageModified)
+  })
+
+  it('returns correct slippage when default was modified by user', () => {
+    const expectedSlippaged = 2
+    const symbol = WSETH2.symbol
+    const slippageModified = getSlippageModification(symbol)
+    const result = selectSlippage(expectedSlippaged, symbol)
+    expect(slippageModified).toBe(slippageMap.get(symbol))
+    expect(result).toBe(expectedSlippaged)
   })
 })

--- a/src/utils/slippage.test.ts
+++ b/src/utils/slippage.test.ts
@@ -1,0 +1,24 @@
+import { slippageMap } from 'constants/slippage'
+import { icETHIndex, WSETH2 } from 'constants/tokens'
+
+import { getSlippageModification } from './slippage'
+
+describe('getSlippageModification()', () => {
+  it('returns null for unaltered slippage', () => {
+    const symbol = 'MVI'
+    const slippage = getSlippageModification(symbol)
+    expect(slippage).toBe(null)
+  })
+
+  it('returns correct slippage for icETH', () => {
+    const symbol = icETHIndex.symbol
+    const slippage = getSlippageModification(symbol)
+    expect(slippage).toBe(slippageMap.get(symbol))
+  })
+
+  it('returns correct slippage for wsETH2', () => {
+    const symbol = WSETH2.symbol
+    const slippage = getSlippageModification(symbol)
+    expect(slippage).toBe(slippageMap.get(symbol))
+  })
+})

--- a/src/utils/slippage.ts
+++ b/src/utils/slippage.ts
@@ -1,5 +1,11 @@
-import { slippageMap } from 'constants/slippage'
+import { slippageDefault, slippageMap } from 'constants/slippage'
 
 export function getSlippageModification(tokenSymbol: string): number | null {
   return slippageMap.get(tokenSymbol) ?? null
+}
+
+export function selectSlippage(slippage: number, tokenSymbol: string): number {
+  if (slippage !== slippageDefault) return slippage
+  const slippageModified = getSlippageModification(tokenSymbol)
+  return slippageModified ?? slippage
 }

--- a/src/utils/slippage.ts
+++ b/src/utils/slippage.ts
@@ -1,0 +1,5 @@
+import { slippageMap } from 'constants/slippage'
+
+export function getSlippageModification(tokenSymbol: string): number | null {
+  return slippageMap.get(tokenSymbol) ?? null
+}

--- a/src/utils/slippage.ts
+++ b/src/utils/slippage.ts
@@ -1,11 +1,11 @@
 import { slippageDefault, slippageMap } from 'constants/slippage'
 
-export function getSlippageModification(tokenSymbol: string): number | null {
+export function getSlippageOverrideOrNull(tokenSymbol: string): number | null {
   return slippageMap.get(tokenSymbol) ?? null
 }
 
 export function selectSlippage(slippage: number, tokenSymbol: string): number {
   if (slippage !== slippageDefault) return slippage
-  const slippageModified = getSlippageModification(tokenSymbol)
-  return slippageModified ?? slippage
+  const slippageOverrride = getSlippageOverrideOrNull(tokenSymbol)
+  return slippageOverrride ?? slippage
 }


### PR DESCRIPTION
## **Summary of Changes**

* Adds slippage map for tokens that should use different slippage settings modifications
* Adds utility functions to get slippage modification based on different factors e.g. when the user set a custom slippage we should always use that value

## **Test Data or Screenshots**

New tests. ✅ 🌟 

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
