### PR TITLE
Fix broken trade button when changing the network

### DIFF
--- a/src/hooks/useTrade.ts
+++ b/src/hooks/useTrade.ts
@@ -92,7 +92,7 @@ export const useTrade = () => {
         console.log('Error sending transaction', error)
       }
     },
-    [address]
+    [address, chainId]
   )
 
   useEffect(() => {


### PR DESCRIPTION


## **Summary of Changes**

Currently the Trade button breaks when changing the network without reloading the page. 
I.e. after switching to the new trade button clicking on "trade" does not trigger a transaction confirmation request.

This behaviour was due to the `useTrade` callback only being updated when the "address" changed but not the chainId, resulting in mismatched chainIds between the zeroExQuote response and what was expected by the `sendTransaction` function.

## **Test Data or Screenshots**

To reproduce this error do the following:
1. Open the app and connect wallet
2. Trigger swap but reject transaction signature in wallet
3. Switch network (but not address)
4. Try swapping on new network.

On the current master version step 4 does not trigger a transaction / signature request in the wallet. 
With this update this should be fixed

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
