### PR TITLE
Add getTokenBalance as memoization trigger

### DIFF
--- a/src/hooks/useTrade.ts
+++ b/src/hooks/useTrade.ts
@@ -92,7 +92,7 @@ export const useTrade = () => {
         console.log('Error sending transaction', error)
       }
     },
-    [address, chainId]
+    [address, chainId, getTokenBalance]
   )
 
   useEffect(() => {


### PR DESCRIPTION
Sometimes the "spendTokenBalance" seemed to be incorrect when trying to execute the trade. (i.e. the token balances had not updated yet and was still at 0 so the trade would not get executed )