### PR TITLE
feat: update supply cap

### DIFF
--- a/src/app/swap/[[...path]]/page.tsx
+++ b/src/app/swap/[[...path]]/page.tsx
@@ -44,7 +44,7 @@ export default function SwapPage() {
         />
       </Box>
       {showSupplyCap && (
-        <Box h='100%' w={['100%', '100%', '500px', '370px']}>
+        <Box h='100%' w={['100%', '100%', '500px', '360px']}>
           <RethSupplyCapContainer
             state={SupplyCapState.capWillExceed}
             overrides={supplyCapOverrides}

--- a/src/components/supply/RethSupplyCap.tsx
+++ b/src/components/supply/RethSupplyCap.tsx
@@ -4,11 +4,7 @@ import { colors, useColorStyles } from '@/lib/styles/colors'
 
 interface RethSupplyCapProps {
   formatted: {
-    // note that this is available icRETH
     available: string
-    // these are cap and total supply of rETH on aave
-    cap: string
-    totalSupply: string
   }
   totalSupplyPercent: number
 }

--- a/src/components/supply/RethSupplyCap.tsx
+++ b/src/components/supply/RethSupplyCap.tsx
@@ -26,66 +26,42 @@ function getColorForProgress(progress: number): string {
 export const RethSupplyCap = (props: RethSupplyCapProps) => {
   const { styles } = useColorStyles()
   const { formatted, totalSupplyPercent } = props
-  const { available, cap, totalSupply } = formatted
   const progressColor = getColorForProgress(totalSupplyPercent)
   return (
-    <Flex align='flex-start' borderRadius='10' direction='column' w='100%'>
-      <Flex
-        align='flex-start'
-        border='1px solid'
-        borderColor={styles.border}
-        borderRadius={'16px'}
-        direction={'column'}
-        p='16px'
-        width='100%'
-      >
-        <Flex align='center'>
-          <Flex ml='32px'>
-            <Flex align='center' justify={'center'}>
-              <CircularProgress
-                position={'absolute'}
-                size='72px'
-                color={progressColor}
-                thickness='8px'
-                value={totalSupplyPercent}
-                zIndex={0}
-              />
-              <Text
-                position={'absolute'}
-                zIndex={1}
-                color={colors.icGray3}
-                fontSize='12px'
-                fontWeight='700'
-              >
-                {`${totalSupplyPercent.toFixed(2)}%`}
-              </Text>
-            </Flex>
-          </Flex>
-          <Flex direction={'column'} ml='48px'>
-            <Text color={colors.icGray3} fontSize='14px' fontWeight='400'>
-              Total supplied
-            </Text>
-            <Text color={styles.text} fontSize='16px' fontWeight='700'>
-              {`${totalSupply} of ${cap}`}
-            </Text>
-          </Flex>
-        </Flex>
+    <Flex
+      align='center'
+      border='1px solid'
+      borderColor={styles.border}
+      borderRadius={'16px'}
+      direction='row'
+      p={'8px'}
+      w='100%'
+    >
+      <Flex alignItems='center' justifyContent='center' position={'relative'}>
+        <CircularProgress
+          position={'relative'}
+          zIndex={0}
+          size='72px'
+          color={progressColor}
+          thickness='8px'
+          value={totalSupplyPercent}
+        />
+        <Text
+          color={colors.icGray3}
+          fontSize='12px'
+          fontWeight='700'
+          position={'absolute'}
+          zIndex={1}
+        >
+          {`${totalSupplyPercent.toFixed(2)}%`}
+        </Text>
       </Flex>
-      <Flex
-        align='flex-start'
-        border='1px solid'
-        borderColor={styles.border}
-        borderRadius={'16px'}
-        direction={'column'}
-        mt='16px'
-        p='16px'
-        w='100%'
-      >
+      <Flex align='flex-start' direction={'column'} ml={'16px'}>
         <Text color={colors.icGray3} fontSize='14px' fontWeight='400'>
           Available to mint
         </Text>
         <Text color={colors.icBlack} fontSize='16px' fontWeight='700'>
-          {`${available} icRETH`}
+          {`${formatted.available} icRETH`}
         </Text>
       </Flex>
     </Flex>

--- a/src/components/supply/index.tsx
+++ b/src/components/supply/index.tsx
@@ -31,16 +31,11 @@ export const RethSupplyCapContainer = (props: RethSupplyCapContainerProps) => {
   const { overrides } = props
   const { data: rethSupplyData } = useRethSupply(true)
   const available = rethSupplyData?.formatted.available ?? 'n/a'
-  const cap = rethSupplyData?.formatted.cap ?? 'n/a'
   const defaultState = rethSupplyData?.state ?? SupplyCapState.available
   const state = props.overrides?.state ?? defaultState
   const shouldShowErrorMessage =
     state === SupplyCapState.capReached ||
     state === SupplyCapState.capWillExceed
-  let totalSupply =
-    state === SupplyCapState.capWillExceed
-      ? overrides?.totalSupply ?? 'n/a'
-      : rethSupplyData?.formatted.totalSupply ?? 'n/a'
   const totalSupplyPercent =
     state === SupplyCapState.capWillExceed
       ? overrides?.totalSupplyPercent ?? 0
@@ -57,7 +52,7 @@ export const RethSupplyCapContainer = (props: RethSupplyCapContainerProps) => {
       <TitleAndDescription />
       <Flex mt='24px'>
         <RethSupplyCap
-          formatted={{ available, cap, totalSupply }}
+          formatted={{ available }}
           totalSupplyPercent={totalSupplyPercent}
         />
       </Flex>

--- a/src/components/supply/useRethSupply.ts
+++ b/src/components/supply/useRethSupply.ts
@@ -6,6 +6,7 @@ import { useWallet } from '@/lib/hooks/useWallet'
 import { SupplyCapState } from './'
 
 interface RethSupplyCapData {
+  available: number
   formatted: {
     available: string
   }
@@ -37,6 +38,7 @@ export const useRethSupply = (
       const state = getSupplyCapState(cap, totalSupply)
       console.log(available, availabeOnAave, availableOnIndex)
       setData({
+        available,
         formatted: {
           available: available.toString(),
         },

--- a/src/components/supply/useRethSupply.ts
+++ b/src/components/supply/useRethSupply.ts
@@ -6,16 +6,10 @@ import { useWallet } from '@/lib/hooks/useWallet'
 import { SupplyCapState } from './'
 
 interface RethSupplyCapData {
-  cap: number
   formatted: {
-    // note that this is available icRETH
     available: string
-    // these are cap and total supply of rETH on aave
-    cap: string
-    totalSupply: string
   }
   state: SupplyCapState
-  totalSupply: number
   totalSupplyPercent: number
 }
 
@@ -36,17 +30,17 @@ export const useRethSupply = (
       const rethProvider = new IndexREthProvider(provider)
       const data = await rethProvider.getSupplyData()
       const { availableSupply, cap, totalSupply } = data.reth
+      const availabeOnAave = availableSupply / IcRethUnits
+      const availableOnIndex = data.icreth.availableSupply
+      const available = Math.min(availabeOnAave, availableOnIndex)
       const totalSupplyPercent = (totalSupply / cap) * 100
       const state = getSupplyCapState(cap, totalSupply)
+      console.log(available, availabeOnAave, availableOnIndex)
       setData({
-        cap,
         formatted: {
-          available: (availableSupply / IcRethUnits).toString(),
-          cap: (cap / IcRethUnits).toFixed(2),
-          totalSupply: (totalSupply / IcRethUnits).toFixed(2),
+          available: available.toString(),
         },
         state,
-        totalSupply,
         totalSupplyPercent,
       })
     } catch (err) {

--- a/src/components/trade/flashmint/index.tsx
+++ b/src/components/trade/flashmint/index.tsx
@@ -5,7 +5,6 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { formatUnits } from '@ethersproject/units'
 import { useConnectModal } from '@rainbow-me/rainbowkit'
 
-import { IcRethUnits } from '@/constants/icreth'
 import { LeveragedRethStakingYield, Token } from '@/constants/tokens'
 import { useApproval } from '@/lib/hooks/useApproval'
 import { useFlashMintQuote } from '@/lib/hooks/useFlashMintQuote'
@@ -164,20 +163,18 @@ const FlashMint = (props: QuickTradeProps) => {
     if (!props.onOverrideSupplyCap) return
     const isMintingIcReth =
       indexToken.symbol === LeveragedRethStakingYield.symbol && isMinting
-    if (isFetchingQuote || !rethSupplyData) {
+    if (isFetchingQuote || !rethSupplyData || !isMintingIcReth) {
       props.onOverrideSupplyCap(undefined)
       return
     }
-    const { cap } = rethSupplyData
     const indexAmountBn = indexTokenAmountWei
     const indexAmount = Number(displayFromWei(indexAmountBn))
-    const totalSupply = rethSupplyData.totalSupply + indexAmount * IcRethUnits
-    const willExceedCap = totalSupply >= cap
+    const willExceedCap = indexAmount > rethSupplyData.available
+    const totalSupplyPercent = 100 + 5
     if (willExceedCap) {
-      const totalSupplyPercent = (totalSupply / cap) * 100
       props.onOverrideSupplyCap({
         state: SupplyCapState.capWillExceed,
-        totalSupply: totalSupply.toFixed(2),
+        totalSupply: '',
         totalSupplyPercent,
       })
       setButtonDisabled(true)


### PR DESCRIPTION
## **Summary of Changes**

* Updates icRETH supply cap visualization
* Now uses min of available icRETH based on Aave and Index supply cap

&nbsp;

## **Test Data or Screenshots**

<img width="1512" alt="Bildschirmfoto 2023-08-22 um 09 43 30" src="https://github.com/IndexCoop/index-app/assets/2104965/d8433f93-43f0-4697-9ef5-b6ce976fc388">


&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
