### PR TITLE
update formatted single token prices

### DIFF
--- a/src/components/swap/hooks/use-swap/formatters/index.test.ts
+++ b/src/components/swap/hooks/use-swap/formatters/index.test.ts
@@ -4,25 +4,25 @@ import { getFormattedTokenPrice, getFormattedTokenPrices } from './'
 
 describe('getFormattedTokenPrice()', () => {
   test('returns correct formatting', async () => {
-    const formattedPrice = getFormattedTokenPrice('ETH', 'USDC', 1500, 1)
+    const formattedPrice = getFormattedTokenPrice('ETH', 'USDC', 1500 / 1)
     const expectedResult = '1 ETH = 1500 USDC'
     expect(formattedPrice).toEqual(expectedResult)
   })
 
   test('returns correct formatting for numbers lower 1', async () => {
-    const formattedPrice = getFormattedTokenPrice('ETH', 'USDC', 1, 234)
-    const expectedResult = '1 ETH = 0.004 USDC'
+    const formattedPrice = getFormattedTokenPrice('ETH', 'USDC', 1 / 234)
+    const expectedResult = '1 ETH = 0.0043 USDC'
     expect(formattedPrice).toEqual(expectedResult)
   })
 })
 
 describe('getFormattedTokenPrices()', () => {
   test('returns correct formatting', async () => {
-    const tokenPrices = getFormattedTokenPrices('ETH', 1500, 'USDC', 1)
+    const tokenPrices = getFormattedTokenPrices('ETH', 1, 1500, 'USDC', 1520, 1)
     const expectedResult: TradeDetailTokenPrices = {
-      inputTokenPrice: '1 ETH = 1500 USDC',
+      inputTokenPrice: '1 ETH = 1520 USDC',
       inputTokenPriceUsd: '($1500.00)',
-      outputTokenPrice: '1 USDC = 0.001 ETH',
+      outputTokenPrice: '1 USDC = 0.0007 ETH',
       outputTokenPriceUsd: '($1.00)',
     }
     expect(tokenPrices).toEqual(expectedResult)

--- a/src/components/swap/hooks/use-swap/formatters/index.ts
+++ b/src/components/swap/hooks/use-swap/formatters/index.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
+import { formatUnits } from 'viem'
 
 import { Token } from '@/constants/tokens'
 import { displayFromWei } from '@/lib/utils'
@@ -21,40 +22,39 @@ export function formattedBalance(
 export function getFormattedTokenPrice(
   tokenSymbol: string,
   comparingTokenSymbol: string,
-  tokenPrice: number,
-  comparingTokenPrice: number
+  tokenPrice: number
 ): string {
-  const percent =
-    comparingTokenPrice === 0 ? 0 : tokenPrice / comparingTokenPrice
-  const isFractional = percent % 1 !== 0
-  const price = isFractional ? percent.toFixed(3) : percent
+  const isFractional = tokenPrice % 1 !== 0
+  const price = isFractional ? tokenPrice.toFixed(4) : tokenPrice
   return `1 ${tokenSymbol} = ${price} ${comparingTokenSymbol}`
 }
 
 export function getFormattedTokenPrices(
   inputTokenSymbol: string,
+  inputTokenAmount: number,
   inputTokenUsd: number,
   outputTokenSymbol: string,
+  outputTokenAmount: number,
   outputTokenUsd: number
 ): TradeDetailTokenPrices {
-  const inputTokenPrice = getFormattedTokenPrice(
+  const inputTokenPrice = outputTokenAmount / inputTokenAmount
+  const outputTokenPrice = inputTokenAmount / outputTokenAmount
+  const inputTokenPriceFormatted = getFormattedTokenPrice(
     inputTokenSymbol,
     outputTokenSymbol,
-    inputTokenUsd,
-    outputTokenUsd
+    inputTokenPrice
+  )
+  const outputTokenPriceFormatted = getFormattedTokenPrice(
+    outputTokenSymbol,
+    inputTokenSymbol,
+    outputTokenPrice
   )
   const inputTokenPriceUsd = `($${inputTokenUsd.toFixed(2)})`
-  const outputTokenPrice = getFormattedTokenPrice(
-    outputTokenSymbol,
-    inputTokenSymbol,
-    outputTokenUsd,
-    inputTokenUsd
-  )
   const outputTokenPriceUsd = `($${outputTokenUsd.toFixed(2)})`
   return {
-    inputTokenPrice,
+    inputTokenPrice: inputTokenPriceFormatted,
     inputTokenPriceUsd,
-    outputTokenPrice,
+    outputTokenPrice: outputTokenPriceFormatted,
     outputTokenPriceUsd,
   }
 }

--- a/src/components/swap/hooks/use-swap/formatters/index.ts
+++ b/src/components/swap/hooks/use-swap/formatters/index.ts
@@ -1,5 +1,4 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { formatUnits } from 'viem'
 
 import { Token } from '@/constants/tokens'
 import { displayFromWei } from '@/lib/utils'

--- a/src/components/swap/hooks/use-swap/index.tsx
+++ b/src/components/swap/hooks/use-swap/index.tsx
@@ -19,6 +19,7 @@ import {
 import { getFormattedPriceImpact } from './formatters/price-impact'
 import { buildTradeDetails } from './trade-details-builder'
 import { useFormattedBalance } from './use-formatted-balance'
+import { formatUnits, parseUnits } from 'viem'
 
 interface SwapData {
   contract: string | null
@@ -170,8 +171,15 @@ export function useSwap(
     () =>
       getFormattedTokenPrices(
         inputToken.symbol,
+        Number(inputTokenAmount),
         selectedQuote?.inputTokenPrice ?? 0,
         outputToken.symbol,
+        Number(
+          formatUnits(
+            BigInt(selectedQuote?.outputTokenAmount.toString() ?? '0'),
+            outputToken.decimals
+          )
+        ),
         selectedQuote?.outputTokenPrice ?? 0
       ),
     [inputToken, outputToken, selectedQuote]

--- a/src/components/swap/hooks/use-swap/index.tsx
+++ b/src/components/swap/hooks/use-swap/index.tsx
@@ -19,7 +19,7 @@ import {
 import { getFormattedPriceImpact } from './formatters/price-impact'
 import { buildTradeDetails } from './trade-details-builder'
 import { useFormattedBalance } from './use-formatted-balance'
-import { formatUnits, parseUnits } from 'viem'
+import { formatUnits } from 'viem'
 
 interface SwapData {
   contract: string | null
@@ -182,7 +182,7 @@ export function useSwap(
         ),
         selectedQuote?.outputTokenPrice ?? 0
       ),
-    [inputToken, outputToken, selectedQuote]
+    [inputToken, inputTokenAmount, outputToken, selectedQuote]
   )
 
   // Trade data


### PR DESCRIPTION
## **Summary of Changes**

* Updates the single token prices displayed in the trade details section to be determined by dividing the quantities


## **Test Data or Screenshots**
<img width="497" alt="Bildschirmfoto 2024-01-03 um 15 12 31" src="https://github.com/IndexCoop/index-app/assets/2104965/ea89e653-b664-4e00-a2ca-4afd231fe6a8">

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
