### PR TITLE
add import order rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,6 +2,21 @@
   "extends": ["next/core-web-vitals", "plugin:@typescript-eslint/recommended"],
   "rules": {
     "no-constant-binary-expression": "error",
-    "@typescript-eslint/no-explicit-any": "off"
+    "@typescript-eslint/no-explicit-any": "off",
+    "import/order": [
+      "error",
+      {
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          "parent",
+          "sibling",
+          "index",
+          "object",
+          "type"
+        ]
+      }
+    ]
   }
 }

--- a/src/app/vaults/page.tsx
+++ b/src/app/vaults/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { colors } from '@/lib/styles/colors'
 import { Flex, Text } from '@chakra-ui/react'
+
+import { colors } from '@/lib/styles/colors'
 import { VaultToken } from './types'
 import VaultTokenCard from './vault-token-card'
 

--- a/src/app/vaults/vault-token-card.tsx
+++ b/src/app/vaults/vault-token-card.tsx
@@ -1,6 +1,8 @@
 import { Button, Divider, Flex, Spacer, Text } from '@chakra-ui/react'
-import { VaultToken } from './types'
+
 import { colors } from '@/lib/styles/colors'
+
+import { VaultToken } from './types'
 
 interface Props {
   vaultToken: VaultToken

--- a/src/components/header/header-v2.tsx
+++ b/src/components/header/header-v2.tsx
@@ -1,10 +1,12 @@
+import { usePathname } from 'next/navigation'
+import NextLink from 'next/link'
+
 import { Flex, HStack, Link, Spacer } from '@chakra-ui/react'
+
+import { colors } from '@/lib/styles/colors'
 
 import { Connect } from './connect'
 import { Logo } from './logo'
-import { colors } from '@/lib/styles/colors'
-import { usePathname } from 'next/navigation'
-import NextLink from 'next/link'
 
 const links = [
   { href: '/swap', label: 'Swap' },

--- a/src/components/swap/components/transaction-review/components/from-to.tsx
+++ b/src/components/swap/components/transaction-review/components/from-to.tsx
@@ -1,7 +1,7 @@
-import { useColorStyles } from '@/lib/styles/colors'
-
 import { ArrowDownIcon } from '@chakra-ui/icons'
 import { Flex, Image, Text } from '@chakra-ui/react'
+
+import { useColorStyles } from '@/lib/styles/colors'
 
 type FromToProps = {
   inputToken: string

--- a/src/components/swap/components/transaction-review/components/override.tsx
+++ b/src/components/swap/components/transaction-review/components/override.tsx
@@ -1,7 +1,7 @@
-import { colors, useColorStyles } from '@/lib/styles/colors'
-
 import { WarningTwoIcon } from '@chakra-ui/icons'
 import { Checkbox, Flex, Text } from '@chakra-ui/react'
+
+import { colors, useColorStyles } from '@/lib/styles/colors'
 
 type OverrideProps = {
   onChange: (isChecked: boolean) => void

--- a/src/components/swap/components/transaction-review/components/simulation.tsx
+++ b/src/components/swap/components/transaction-review/components/simulation.tsx
@@ -1,7 +1,7 @@
-import { colors, useColorStyles } from '@/lib/styles/colors'
-
 import { CheckCircleIcon, WarningIcon } from '@chakra-ui/icons'
 import { Flex, Spacer, Spinner, Text } from '@chakra-ui/react'
+
+import { colors, useColorStyles } from '@/lib/styles/colors'
 
 export enum TransactionReviewSimulationState {
   default,

--- a/src/components/swap/components/transaction-review/index.tsx
+++ b/src/components/swap/components/transaction-review/index.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
 
-import { useColorStyles } from '@/lib/styles/colors'
-
 import { CheckCircleIcon, WarningIcon } from '@chakra-ui/icons'
 import {
   Box,
@@ -20,6 +18,7 @@ import {
 import { Quote, QuoteType } from '@/lib/hooks/use-best-quote/types'
 import { useSimulateQuote } from '@/lib/hooks/use-simulate-quote'
 import { useTrade } from '@/lib/hooks/use-trade'
+import { useColorStyles } from '@/lib/styles/colors'
 import { displayFromWei } from '@/lib/utils'
 import { getBlockExplorerContractUrl } from '@/lib/utils/block-explorer'
 

--- a/src/components/swap/hooks/use-swap/index.tsx
+++ b/src/components/swap/hooks/use-swap/index.tsx
@@ -1,5 +1,6 @@
 import { BigNumber } from 'ethers'
 import { useMemo } from 'react'
+import { formatUnits } from 'viem'
 
 import { Token } from '@/constants/tokens'
 import { QuoteResult, QuoteType } from '@/lib/hooks/use-best-quote/types'
@@ -19,7 +20,6 @@ import {
 import { getFormattedPriceImpact } from './formatters/price-impact'
 import { buildTradeDetails } from './trade-details-builder'
 import { useFormattedBalance } from './use-formatted-balance'
-import { formatUnits } from 'viem'
 
 interface SwapData {
   contract: string | null

--- a/src/components/swap/index.tsx
+++ b/src/components/swap/index.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useDebounce } from 'use-debounce'
 
-import { colors } from '@/lib/styles/colors'
-
 import { UpDownIcon } from '@chakra-ui/icons'
 import { Box, Flex, IconButton, Text, useDisclosure } from '@chakra-ui/react'
 import { useConnectModal } from '@rainbow-me/rainbowkit'
@@ -14,11 +12,11 @@ import { useApproval } from '@/lib/hooks/use-approval'
 import { useNetwork } from '@/lib/hooks/use-network'
 import { useBestQuote } from '@/lib/hooks/use-best-quote'
 import { useTokenlists } from '@/lib/hooks/use-tokenlists'
-import { useTradeButton } from './hooks/use-trade-button'
 import { useWallet } from '@/lib/hooks/use-wallet'
 import { useProtection } from '@/lib/providers/protection'
 import { useSelectedToken } from '@/lib/providers/selected-token-provider'
 import { useSlippage } from '@/lib/providers/slippage'
+import { colors } from '@/lib/styles/colors'
 import { isValidTokenInput } from '@/lib/utils'
 import { getNativeToken, getTokenBySymbol } from '@/lib/utils/tokens'
 
@@ -33,6 +31,7 @@ import {
   WarningType,
 } from './components/warning'
 import { useSwap } from './hooks/use-swap'
+import { useTradeButton } from './hooks/use-trade-button'
 import {
   TradeButtonState,
   useTradeButtonState,

--- a/src/components/trade-button/index.tsx
+++ b/src/components/trade-button/index.tsx
@@ -1,6 +1,6 @@
-import { colors } from '@/lib/styles/colors'
-
 import { Button } from '@chakra-ui/react'
+
+import { colors } from '@/lib/styles/colors'
 
 interface TradeButtonProps {
   label: string

--- a/src/lib/styles/theme.ts
+++ b/src/lib/styles/theme.ts
@@ -1,3 +1,6 @@
+import { extendTheme, ThemeConfig } from '@chakra-ui/react'
+import { darkTheme, Theme } from '@rainbow-me/rainbowkit'
+
 import merge from 'lodash.merge'
 import { Button } from '../styles/button'
 import { Checkbox } from '../styles/checkbox'
@@ -6,9 +9,6 @@ import { global } from '../styles/global'
 import { Heading } from '../styles/heading'
 import { Tabs } from '../styles/tabs'
 import { Text } from '../styles/text'
-
-import { extendTheme, ThemeConfig } from '@chakra-ui/react'
-import { darkTheme, Theme } from '@rainbow-me/rainbowkit'
 
 const config: ThemeConfig = {
   initialColorMode: 'light',


### PR DESCRIPTION
## **Summary of Changes**

* Adds the eslint `import/oder` rule to keep imports sorted the right way (defined in `groups`)

### Resources
https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md


###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
