### PR TITLE
Fix: Take absolute value of Dex Swap price impact

### DIFF
--- a/src/lib/hooks/use-best-quote/utils/index-token-amount.test.ts
+++ b/src/lib/hooks/use-best-quote/utils/index-token-amount.test.ts
@@ -1,94 +1,20 @@
-import { formatUnits } from 'viem'
+import { formatUnits, parseUnits } from 'viem'
 
-import { ZeroExData } from '@/lib/utils/api/zeroex-utils'
-import { toWei } from '@/lib/utils'
-
-import { maxPriceImpact } from '../config'
 import { getIndexTokenAmount } from './index-token-amount'
 
 describe('getIndexTokenAmount - redeeming', () => {
   it('returns input token amount directly', async () => {
     const isMinting = false
-    const expectedIndexTokenAmount = toWei('1', 18)
-    const indexTokenAmount = getIndexTokenAmount(
-      isMinting,
-      '1',
-      18,
-      18,
-      0,
-      0,
-      null
-    )
-    expect(indexTokenAmount.toString()).toEqual(
-      expectedIndexTokenAmount.toString()
-    )
+    const expectedIndexTokenAmount = parseUnits('1', 18)
+    const indexTokenAmount = getIndexTokenAmount(isMinting, '1', 18, 18, 0, 0)
+    expect(indexTokenAmount).toEqual(expectedIndexTokenAmount)
   })
 })
 
 describe('getIndexTokenAmount - minting', () => {
   const outputAdjust = 0.99
 
-  it('returns buy amount (0x data)', async () => {
-    const isMinting = true
-    const dexData = {
-      buyAmount: '2000000000000000000',
-    } as ZeroExData
-    const indexTokenAmount = getIndexTokenAmount(
-      isMinting,
-      '1',
-      18,
-      18,
-      0,
-      0,
-      dexData
-    )
-    expect(indexTokenAmount.toString()).toEqual(dexData.buyAmount.toString())
-  })
-
-  it('returns buy amount (0x data) if price impact is below max', async () => {
-    const isMinting = true
-    const dexData = {
-      estimatedPriceImpact: '0.1',
-      buyAmount: '2000000000000000000',
-    } as ZeroExData
-    const indexTokenAmount = getIndexTokenAmount(
-      isMinting,
-      '1',
-      18,
-      18,
-      0,
-      0,
-      dexData
-    )
-    expect(indexTokenAmount.toString()).toEqual(dexData.buyAmount.toString())
-  })
-
-  it('returns approx amount if price impact is above max', async () => {
-    const isMinting = true
-    const inputTokenAmount = '1'
-    const inputTokenPrice = 2
-    const outputTokenPrice = 3
-    const dexData = {
-      estimatedPriceImpact: maxPriceImpact.toString(),
-      buyAmount: '2000000000000000000',
-    } as ZeroExData
-    const indexTokenAmount = getIndexTokenAmount(
-      isMinting,
-      inputTokenAmount,
-      18,
-      18,
-      inputTokenPrice,
-      outputTokenPrice,
-      dexData
-    )
-    const inputTokenTotal = parseFloat(inputTokenAmount) * inputTokenPrice
-    const approxOutputAmount =
-      (inputTokenTotal / outputTokenPrice) * outputAdjust
-    const expectedAmount = toWei(approxOutputAmount, 18)
-    expect(indexTokenAmount.toString()).toEqual(expectedAmount.toString())
-  })
-
-  it('returns approx amount if no 0x data', async () => {
+  it('returns approx. index token amount', async () => {
     const isMinting = true
     const inputTokenAmount = '1'
     const inputTokenPrice = 2
@@ -99,18 +25,17 @@ describe('getIndexTokenAmount - minting', () => {
       18,
       18,
       inputTokenPrice,
-      outputTokenPrice,
-      null
+      outputTokenPrice
     )
-    const inputTokenTotal = parseFloat(inputTokenAmount) * inputTokenPrice
+    const inputTokenAmountUsd = parseFloat(inputTokenAmount) * inputTokenPrice
     const approxOutputAmount =
-      (inputTokenTotal / outputTokenPrice) * outputAdjust
-    const expectedAmount = toWei(approxOutputAmount, 18)
+      (inputTokenAmountUsd / outputTokenPrice) * outputAdjust
+    const expectedAmount = parseUnits(approxOutputAmount.toString(), 18)
     const indexTokenPriceTotal =
       Number(formatUnits(BigInt(indexTokenAmount.toString()), 18)) *
       outputTokenPrice
-    expect(indexTokenAmount.toString()).toEqual(expectedAmount.toString())
-    expect(indexTokenPriceTotal).toBeCloseTo(inputTokenTotal, 1)
+    expect(indexTokenAmount).toEqual(expectedAmount)
+    expect(indexTokenPriceTotal).toBeCloseTo(inputTokenAmountUsd, 1)
   })
 
   it('returns index token amount with correct decimals for usdc input', async () => {
@@ -124,17 +49,16 @@ describe('getIndexTokenAmount - minting', () => {
       6,
       18,
       inputTokenPrice,
-      outputTokenPrice,
-      null
+      outputTokenPrice
     )
     const inputTokenTotal = parseFloat(inputTokenAmount) * inputTokenPrice
     const approxOutputAmount =
       (inputTokenTotal / outputTokenPrice) * outputAdjust
-    const expectedAmount = toWei(approxOutputAmount, 18)
+    const expectedAmount = parseUnits(approxOutputAmount.toString(), 18)
     const indexTokenPriceTotal =
       Number(formatUnits(BigInt(indexTokenAmount.toString()), 18)) *
       outputTokenPrice
-    expect(indexTokenAmount.toString()).toEqual(expectedAmount.toString())
+    expect(indexTokenAmount).toEqual(expectedAmount)
     expect(indexTokenPriceTotal).toBeCloseTo(inputTokenTotal, 1)
   })
 })

--- a/src/lib/hooks/use-best-quote/utils/index-token-amount.ts
+++ b/src/lib/hooks/use-best-quote/utils/index-token-amount.ts
@@ -1,8 +1,4 @@
-import { BigNumber } from '@ethersproject/bignumber'
-
-import { toWei } from '@/lib/utils'
-
-import { maxPriceImpact } from '../config'
+import { parseUnits } from 'viem'
 
 export const getIndexTokenAmount = (
   isMinting: boolean,
@@ -10,29 +6,14 @@ export const getIndexTokenAmount = (
   inputTokenDecimals: number,
   outputTokenDecimals: number,
   inputTokenPrice: number,
-  outputTokenPrice: number,
-  dexSwapOption: { buyAmount: string; estimatedPriceImpact: string } | null
-): BigNumber => {
+  outputTokenPrice: number
+): bigint => {
   if (!isMinting) {
-    return toWei(inputTokenAmount, inputTokenDecimals)
+    return parseUnits(inputTokenAmount, inputTokenDecimals)
   }
-
-  let indexTokenAmount = dexSwapOption
-    ? BigNumber.from(dexSwapOption?.buyAmount ?? '0')
-    : BigNumber.from('0')
-
-  const priceImpact =
-    dexSwapOption && dexSwapOption.estimatedPriceImpact
-      ? Math.abs(parseFloat(dexSwapOption.estimatedPriceImpact))
-      : 0
-
-  if (!dexSwapOption || priceImpact >= maxPriceImpact) {
-    // Recalculate the exchange issue/redeem quotes if not enough DEX liquidity
-    const sellTokenTotal = parseFloat(inputTokenAmount) * inputTokenPrice
-    const approxOutputAmount =
-      outputTokenPrice === 0 ? 0 : (sellTokenTotal / outputTokenPrice) * 0.99
-    indexTokenAmount = toWei(approxOutputAmount, outputTokenDecimals)
-  }
-
-  return indexTokenAmount
+  // When minting - calculate an approximate index token amount for FlashMint quotes
+  const inputTokenAmountUsd = parseFloat(inputTokenAmount) * inputTokenPrice
+  const approxOutputAmount =
+    outputTokenPrice === 0 ? 0 : (inputTokenAmountUsd / outputTokenPrice) * 0.99
+  return parseUnits(approxOutputAmount.toString(), outputTokenDecimals)
 }

--- a/src/lib/hooks/use-best-quote/utils/index-token-amount.ts
+++ b/src/lib/hooks/use-best-quote/utils/index-token-amount.ts
@@ -23,7 +23,7 @@ export const getIndexTokenAmount = (
 
   const priceImpact =
     dexSwapOption && dexSwapOption.estimatedPriceImpact
-      ? parseFloat(dexSwapOption.estimatedPriceImpact)
+      ? Math.abs(parseFloat(dexSwapOption.estimatedPriceImpact))
       : 0
 
   if (!dexSwapOption || priceImpact >= maxPriceImpact) {


### PR DESCRIPTION
## **Summary of Changes**

Take the absolute value of `dexSwapOption.estimatedPriceImpact` because it's usually a negative number. This gives a much better approximate index token amount when minting.  

## **Test Data or Screenshots**

https://cdn.discordapp.com/attachments/930566173614022717/1199063142777491526/DevTools_-_localhost_3000_swap.png?ex=65c12d92&is=65aeb892&hm=df23b545448aea86136412417ff6d431c0fa275ce3fe7cb0e4c2e3e8eac03ea1&

![Index_App___Buy___Sell_Our_Tokens](https://github.com/IndexCoop/index-app/assets/1253142/0014f2a5-ece7-452b-a322-81f9847cc132)


###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
