### PR TITLE
refactor: simplify index token amount

### DIFF
--- a/src/lib/hooks/use-best-quote/index.ts
+++ b/src/lib/hooks/use-best-quote/index.ts
@@ -93,21 +93,10 @@ export const useBestQuote = () => {
       const fetchMoreQuotes = async () => {
         if (canFlashmintIndexToken) {
           console.log('canFlashmintIndexToken')
-          let dexData = null
-          if (quote0x !== null) {
-            const buyAmount = isMinting
-              ? quote0x.indexTokenAmount.toString()
-              : quote0x.inputOutputTokenAmount.toString()
-            dexData = {
-              buyAmount,
-              estimatedPriceImpact: quote0x.priceImpact?.toString() ?? '5',
-            }
-          }
           quoteFlashMint = await getFlashMintQuote(
             {
               ...request,
               chainId,
-              dexData,
               inputTokenAmountWei,
               inputTokenPrice,
               outputTokenPrice,
@@ -191,7 +180,6 @@ export const useBestQuote = () => {
 
 interface FlashMintQuoteRequest extends IndexQuoteRequest {
   chainId: number
-  dexData: { buyAmount: string; estimatedPriceImpact: string } | null
   inputTokenAmountWei: BigNumber
   nativeTokenPrice: number
 }
@@ -203,7 +191,6 @@ async function getFlashMintQuote(
 ) {
   const {
     chainId,
-    dexData,
     inputToken,
     inputTokenAmount,
     inputTokenAmountWei,

--- a/src/lib/hooks/use-best-quote/index.ts
+++ b/src/lib/hooks/use-best-quote/index.ts
@@ -222,8 +222,7 @@ async function getFlashMintQuote(
     inputToken.decimals,
     outputToken.decimals,
     inputTokenPrice,
-    outputTokenPrice,
-    dexData
+    outputTokenPrice
   )
 
   const gasStation = new GasStation(provider)
@@ -237,7 +236,7 @@ async function getFlashMintQuote(
       isMinting,
       inputToken,
       outputToken,
-      indexTokenAmount,
+      BigNumber.from(indexTokenAmount.toString()),
       inputTokenPrice,
       outputTokenPrice,
       nativeTokenPrice,
@@ -272,14 +271,14 @@ async function getFlashMintQuote(
     console.log(diff >= 0, 100 + Math.round(Math.abs(diff)) - buffer)
     if (diff < 0) {
       // The quote input amount is too high, reduce
-      indexTokenAmount = indexTokenAmount
-        .mul(100 - Math.floor(Math.abs(diff)) - buffer)
-        .div(100)
+      indexTokenAmount =
+        (indexTokenAmount * BigInt(100 - Math.floor(Math.abs(diff)) - buffer)) /
+        BigInt(100)
     } else {
       // The quote input amount is too low from the original input, increase
-      indexTokenAmount = indexTokenAmount
-        .mul(100 + Math.round(Math.abs(diff)) - buffer)
-        .div(100)
+      indexTokenAmount =
+        (indexTokenAmount * BigInt(100 + Math.round(Math.abs(diff)) - buffer)) /
+        BigInt(100)
     }
   }
 }

--- a/src/lib/hooks/use-best-quote/utils/index-token-amount.test.ts
+++ b/src/lib/hooks/use-best-quote/utils/index-token-amount.test.ts
@@ -1,94 +1,20 @@
-import { formatUnits } from 'viem'
+import { formatUnits, parseUnits } from 'viem'
 
-import { ZeroExData } from '@/lib/utils/api/zeroex-utils'
-import { toWei } from '@/lib/utils'
-
-import { maxPriceImpact } from '../config'
 import { getIndexTokenAmount } from './index-token-amount'
 
 describe('getIndexTokenAmount - redeeming', () => {
   it('returns input token amount directly', async () => {
     const isMinting = false
-    const expectedIndexTokenAmount = toWei('1', 18)
-    const indexTokenAmount = getIndexTokenAmount(
-      isMinting,
-      '1',
-      18,
-      18,
-      0,
-      0,
-      null
-    )
-    expect(indexTokenAmount.toString()).toEqual(
-      expectedIndexTokenAmount.toString()
-    )
+    const expectedIndexTokenAmount = parseUnits('1', 18)
+    const indexTokenAmount = getIndexTokenAmount(isMinting, '1', 18, 18, 0, 0)
+    expect(indexTokenAmount.toBigInt()).toEqual(expectedIndexTokenAmount)
   })
 })
 
 describe('getIndexTokenAmount - minting', () => {
   const outputAdjust = 0.99
 
-  it('returns buy amount (0x data)', async () => {
-    const isMinting = true
-    const dexData = {
-      buyAmount: '2000000000000000000',
-    } as ZeroExData
-    const indexTokenAmount = getIndexTokenAmount(
-      isMinting,
-      '1',
-      18,
-      18,
-      0,
-      0,
-      dexData
-    )
-    expect(indexTokenAmount.toString()).toEqual(dexData.buyAmount.toString())
-  })
-
-  it('returns buy amount (0x data) if price impact is below max', async () => {
-    const isMinting = true
-    const dexData = {
-      estimatedPriceImpact: '0.1',
-      buyAmount: '2000000000000000000',
-    } as ZeroExData
-    const indexTokenAmount = getIndexTokenAmount(
-      isMinting,
-      '1',
-      18,
-      18,
-      0,
-      0,
-      dexData
-    )
-    expect(indexTokenAmount.toString()).toEqual(dexData.buyAmount.toString())
-  })
-
-  it('returns approx amount if price impact is above max', async () => {
-    const isMinting = true
-    const inputTokenAmount = '1'
-    const inputTokenPrice = 2
-    const outputTokenPrice = 3
-    const dexData = {
-      estimatedPriceImpact: maxPriceImpact.toString(),
-      buyAmount: '2000000000000000000',
-    } as ZeroExData
-    const indexTokenAmount = getIndexTokenAmount(
-      isMinting,
-      inputTokenAmount,
-      18,
-      18,
-      inputTokenPrice,
-      outputTokenPrice,
-      dexData
-    )
-    const inputTokenTotal = parseFloat(inputTokenAmount) * inputTokenPrice
-    const approxOutputAmount =
-      (inputTokenTotal / outputTokenPrice) * outputAdjust
-    const expectedAmount = toWei(approxOutputAmount, 18)
-    expect(indexTokenAmount.toString()).toEqual(expectedAmount.toString())
-  })
-
-  it('returns approx amount if no 0x data', async () => {
+  it('returns approx. index token amount', async () => {
     const isMinting = true
     const inputTokenAmount = '1'
     const inputTokenPrice = 2
@@ -99,18 +25,17 @@ describe('getIndexTokenAmount - minting', () => {
       18,
       18,
       inputTokenPrice,
-      outputTokenPrice,
-      null
+      outputTokenPrice
     )
-    const inputTokenTotal = parseFloat(inputTokenAmount) * inputTokenPrice
+    const inputTokenAmountUsd = parseFloat(inputTokenAmount) * inputTokenPrice
     const approxOutputAmount =
-      (inputTokenTotal / outputTokenPrice) * outputAdjust
-    const expectedAmount = toWei(approxOutputAmount, 18)
+      (inputTokenAmountUsd / outputTokenPrice) * outputAdjust
+    const expectedAmount = parseUnits(approxOutputAmount.toString(), 18)
     const indexTokenPriceTotal =
       Number(formatUnits(BigInt(indexTokenAmount.toString()), 18)) *
       outputTokenPrice
     expect(indexTokenAmount.toString()).toEqual(expectedAmount.toString())
-    expect(indexTokenPriceTotal).toBeCloseTo(inputTokenTotal, 1)
+    expect(indexTokenPriceTotal).toBeCloseTo(inputTokenAmountUsd, 1)
   })
 
   it('returns index token amount with correct decimals for usdc input', async () => {
@@ -124,13 +49,12 @@ describe('getIndexTokenAmount - minting', () => {
       6,
       18,
       inputTokenPrice,
-      outputTokenPrice,
-      null
+      outputTokenPrice
     )
     const inputTokenTotal = parseFloat(inputTokenAmount) * inputTokenPrice
     const approxOutputAmount =
       (inputTokenTotal / outputTokenPrice) * outputAdjust
-    const expectedAmount = toWei(approxOutputAmount, 18)
+    const expectedAmount = parseUnits(approxOutputAmount.toString(), 18)
     const indexTokenPriceTotal =
       Number(formatUnits(BigInt(indexTokenAmount.toString()), 18)) *
       outputTokenPrice

--- a/src/lib/hooks/use-best-quote/utils/index-token-amount.test.ts
+++ b/src/lib/hooks/use-best-quote/utils/index-token-amount.test.ts
@@ -7,7 +7,7 @@ describe('getIndexTokenAmount - redeeming', () => {
     const isMinting = false
     const expectedIndexTokenAmount = parseUnits('1', 18)
     const indexTokenAmount = getIndexTokenAmount(isMinting, '1', 18, 18, 0, 0)
-    expect(indexTokenAmount.toBigInt()).toEqual(expectedIndexTokenAmount)
+    expect(indexTokenAmount).toEqual(expectedIndexTokenAmount)
   })
 })
 
@@ -34,7 +34,7 @@ describe('getIndexTokenAmount - minting', () => {
     const indexTokenPriceTotal =
       Number(formatUnits(BigInt(indexTokenAmount.toString()), 18)) *
       outputTokenPrice
-    expect(indexTokenAmount.toString()).toEqual(expectedAmount.toString())
+    expect(indexTokenAmount).toEqual(expectedAmount)
     expect(indexTokenPriceTotal).toBeCloseTo(inputTokenAmountUsd, 1)
   })
 
@@ -58,7 +58,7 @@ describe('getIndexTokenAmount - minting', () => {
     const indexTokenPriceTotal =
       Number(formatUnits(BigInt(indexTokenAmount.toString()), 18)) *
       outputTokenPrice
-    expect(indexTokenAmount.toString()).toEqual(expectedAmount.toString())
+    expect(indexTokenAmount).toEqual(expectedAmount)
     expect(indexTokenPriceTotal).toBeCloseTo(inputTokenTotal, 1)
   })
 })

--- a/src/lib/hooks/use-best-quote/utils/index-token-amount.ts
+++ b/src/lib/hooks/use-best-quote/utils/index-token-amount.ts
@@ -2,37 +2,21 @@ import { BigNumber } from '@ethersproject/bignumber'
 
 import { toWei } from '@/lib/utils'
 
-import { maxPriceImpact } from '../config'
-
 export const getIndexTokenAmount = (
   isMinting: boolean,
   inputTokenAmount: string,
   inputTokenDecimals: number,
   outputTokenDecimals: number,
   inputTokenPrice: number,
-  outputTokenPrice: number,
-  dexSwapOption: { buyAmount: string; estimatedPriceImpact: string } | null
+  outputTokenPrice: number
 ): BigNumber => {
   if (!isMinting) {
     return toWei(inputTokenAmount, inputTokenDecimals)
   }
-
-  let indexTokenAmount = dexSwapOption
-    ? BigNumber.from(dexSwapOption?.buyAmount ?? '0')
-    : BigNumber.from('0')
-
-  const priceImpact =
-    dexSwapOption && dexSwapOption.estimatedPriceImpact
-      ? Math.abs(parseFloat(dexSwapOption.estimatedPriceImpact))
-      : 0
-
-  if (!dexSwapOption || priceImpact >= maxPriceImpact) {
-    // Recalculate the exchange issue/redeem quotes if not enough DEX liquidity
-    const sellTokenTotal = parseFloat(inputTokenAmount) * inputTokenPrice
-    const approxOutputAmount =
-      outputTokenPrice === 0 ? 0 : (sellTokenTotal / outputTokenPrice) * 0.99
-    indexTokenAmount = toWei(approxOutputAmount, outputTokenDecimals)
-  }
-
+  // Recalculate the exchange issue/redeem quotes if not enough DEX liquidity
+  const inputTokenAmountUsd = parseFloat(inputTokenAmount) * inputTokenPrice
+  const approxOutputAmount =
+    outputTokenPrice === 0 ? 0 : (inputTokenAmountUsd / outputTokenPrice) * 0.99
+  const indexTokenAmount = toWei(approxOutputAmount, outputTokenDecimals)
   return indexTokenAmount
 }

--- a/src/lib/hooks/use-best-quote/utils/index-token-amount.ts
+++ b/src/lib/hooks/use-best-quote/utils/index-token-amount.ts
@@ -1,6 +1,4 @@
-import { BigNumber } from '@ethersproject/bignumber'
-
-import { toWei } from '@/lib/utils'
+import { parseUnits } from 'viem'
 
 export const getIndexTokenAmount = (
   isMinting: boolean,
@@ -9,14 +7,13 @@ export const getIndexTokenAmount = (
   outputTokenDecimals: number,
   inputTokenPrice: number,
   outputTokenPrice: number
-): BigNumber => {
+): bigint => {
   if (!isMinting) {
-    return toWei(inputTokenAmount, inputTokenDecimals)
+    return parseUnits(inputTokenAmount, inputTokenDecimals)
   }
-  // Recalculate the exchange issue/redeem quotes if not enough DEX liquidity
+  // When minting - calculate an approximate index token amount for FlashMint quotes
   const inputTokenAmountUsd = parseFloat(inputTokenAmount) * inputTokenPrice
   const approxOutputAmount =
     outputTokenPrice === 0 ? 0 : (inputTokenAmountUsd / outputTokenPrice) * 0.99
-  const indexTokenAmount = toWei(approxOutputAmount, outputTokenDecimals)
-  return indexTokenAmount
+  return parseUnits(approxOutputAmount.toString(), outputTokenDecimals)
 }


### PR DESCRIPTION
## **Summary of Changes**

Thanks to @edkim fix (https://github.com/IndexCoop/index-app/pull/969), I realized that the whole `getIndexTokenAmount` could be simplified. Because the dex data is actually not relevant at all. (This was more relevant back in the days when the app worked differently.)

So this cleans up the function and also introduces `bigint`. Tests are updated accordingly. ✅ 

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
