### PR TITLE
fix: Add rewrite for safe manifest

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -47,6 +47,14 @@ const nextConfig = {
       },
     ]
   },
+  async rewrites() {
+    return [
+      {
+        source: '/swap/manifest.json',
+        destination: '/manifest.json'
+      }
+    ]
+  },
   webpack: (config) => {
     config.resolve.fallback = { fs: false, net: false, tls: false }
     config.externals.push('pino-pretty', 'lokijs', 'encoding')


### PR DESCRIPTION
## **Summary of Changes**

Safe requests the `manifest.json` from the base app URL (`/swap` in our case).

## **Test Data or Screenshots**

&nbsp;

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
