### PR TITLE
disable minting of FLIs

### DIFF
--- a/src/components/swap/hooks/use-trade-button-state.tsx
+++ b/src/components/swap/hooks/use-trade-button-state.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from 'react'
 
+import {
+  Bitcoin2xFlexibleLeverageIndex,
+  Ethereum2xFlexibleLeverageIndex,
+  Token,
+} from '@/constants/tokens'
 import { useNetwork } from '@/lib/hooks/use-network'
 import { useWallet } from '@/lib/hooks/use-wallet'
 
@@ -12,6 +17,7 @@ export enum TradeButtonState {
   fetchingError,
   insufficientFunds,
   loading,
+  notAvailable,
   wrongNetwork,
 }
 
@@ -21,6 +27,7 @@ export const useTradeButtonState = (
   shouldApprove: boolean,
   isApproved: boolean,
   isApproving: boolean,
+  outputToken: Token,
   sellTokenAmount: string,
 ) => {
   const { address } = useWallet()
@@ -33,6 +40,11 @@ export const useTradeButtonState = (
       // Order of the checks matters
       if (!address) return TradeButtonState.connectWallet
       if (!isSupportedNetwork) return TradeButtonState.wrongNetwork
+      if (
+        outputToken === Ethereum2xFlexibleLeverageIndex ||
+        outputToken === Bitcoin2xFlexibleLeverageIndex
+      )
+        return TradeButtonState.notAvailable
       if (sellTokenAmount === '0') return TradeButtonState.enterAmount
       if (hasFetchingError) return TradeButtonState.fetchingError
       if (hasInsufficientFunds) return TradeButtonState.insufficientFunds
@@ -48,6 +60,7 @@ export const useTradeButtonState = (
     isApproved,
     isApproving,
     isSupportedNetwork,
+    outputToken,
     sellTokenAmount,
     shouldApprove,
   ])

--- a/src/components/swap/hooks/use-trade-button.tsx
+++ b/src/components/swap/hooks/use-trade-button.tsx
@@ -23,6 +23,8 @@ export const useTradeButton = (buttonState: TradeButtonState) => {
         return 'Insufficient funds'
       case TradeButtonState.loading:
         return 'Swapping...'
+      case TradeButtonState.notAvailable:
+        return 'Not available'
       case TradeButtonState.wrongNetwork:
         return 'Wrong Network'
       default:
@@ -40,6 +42,7 @@ export const useTradeButton = (buttonState: TradeButtonState) => {
       case TradeButtonState.enterAmount:
       case TradeButtonState.insufficientFunds:
       case TradeButtonState.loading:
+      case TradeButtonState.notAvailable:
       case TradeButtonState.wrongNetwork:
         return true
       default:

--- a/src/components/swap/index.tsx
+++ b/src/components/swap/index.tsx
@@ -154,6 +154,7 @@ export const Swap = (props: SwapProps) => {
     shouldApprove,
     isApprovedForSwap,
     isApprovingForSwap,
+    outputToken,
     sellTokenAmount,
   )
   const { buttonLabel, isDisabled } = useTradeButton(buttonState)


### PR DESCRIPTION
## **Summary of Changes**

* Disables minting of ETH2x-FLI and BTC2x-FLI by disabling trade button w/ `Not available`

## **Test Data or Screenshots**

<img width="1512" alt="Bildschirmfoto 2024-03-20 um 09 28 27" src="https://github.com/IndexCoop/index-app/assets/2104965/9592700a-f96d-4d73-a9e2-8ab89842438d">


###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
