### PR TITLE
fix: override simulation

### DIFF
--- a/src/components/swap/components/transaction-review/components/override.tsx
+++ b/src/components/swap/components/transaction-review/components/override.tsx
@@ -1,35 +1,25 @@
 import { WarningTwoIcon } from '@chakra-ui/icons'
-import { Checkbox, Flex, Text } from '@chakra-ui/react'
+import { Checkbox } from '@chakra-ui/react'
 
-import { colors, useColorStyles } from '@/lib/styles/colors'
+import { colors } from '@/lib/styles/colors'
 
 type OverrideProps = {
   onChange: (isChecked: boolean) => void
 }
 
 export const Override = (props: OverrideProps) => {
-  const { isDarkMode, styles } = useColorStyles()
-  const backgroundColor = isDarkMode ? colors.ic.gray[600] : colors.ic.gray[100]
   return (
-    <Flex
-      align='flex-start'
-      background={backgroundColor}
-      borderRadius='10'
-      direction='column'
-      p='16px'
-    >
-      <Flex align='center'>
-        <WarningTwoIcon color={styles.text} />
-        <Text color={styles.text} fontSize='14px' mx='16px'>
+    <div className='bg-ic-gray-100 flex flex-col items-start gap-2 rounded-xl p-4'>
+      <div className='items-top flex flex-row'>
+        <WarningTwoIcon color={colors.ic.black} />
+        <p className='text-ic-black mx-4 text-sm'>
           This tx would likely fail. Check override and press the trade button
           again to execute anyway.
-        </Text>
-      </Flex>
-      <Flex mt='8px'>
-        <Checkbox onChange={(e) => props.onChange(e.target.checked)}>
-          Override?
-        </Checkbox>
-      </Flex>
-    </Flex>
+        </p>
+      </div>
+      <Checkbox onChange={(e) => props.onChange(e.target.checked)}>
+        Override?
+      </Checkbox>
+    </div>
   )
 }

--- a/src/components/swap/components/transaction-review/provider.tsx
+++ b/src/components/swap/components/transaction-review/provider.tsx
@@ -11,6 +11,7 @@ import { ReviewProps } from './components/review'
 import { TransactionReviewSimulationState } from './components/simulation'
 
 export function useTransactionReview(props: ReviewProps) {
+  const decimals = 10
   const { onSubmitWithSuccess, transactionReview } = props
   const { logEvent } = useAnalytics()
   const { executeTrade, isTransacting } = useTrade()
@@ -64,7 +65,6 @@ export function useTransactionReview(props: ReviewProps) {
     [transactionReview],
   )
 
-  const decimals = 10
   const formattedInputTokenAmount =
     displayFromWei(
       transactionReview.inputTokenAmount,

--- a/src/components/swap/components/transaction-review/provider.tsx
+++ b/src/components/swap/components/transaction-review/provider.tsx
@@ -31,6 +31,7 @@ export function useTransactionReview(props: ReviewProps) {
   }, [])
 
   useEffect(() => {
+    setOverride(false)
     // Reset state for new data
     setSimulationState(TransactionReviewSimulationState.default)
   }, [transactionReview])
@@ -123,6 +124,7 @@ export function useTransactionReview(props: ReviewProps) {
       if (!isSuccess) return
     }
     const success = await makeTrade(override)
+    setOverride(false)
     if (success === null) return
     onSubmitWithSuccess(success)
   }

--- a/src/components/swap/components/transaction-review/provider.tsx
+++ b/src/components/swap/components/transaction-review/provider.tsx
@@ -113,14 +113,15 @@ export function useTransactionReview(props: ReviewProps) {
   }
 
   const onSubmit = async () => {
-    setSimulationState(TransactionReviewSimulationState.loading)
-    const isSuccess = await simulateTrade()
-    const state = isSuccess
-      ? TransactionReviewSimulationState.success
-      : TransactionReviewSimulationState.failure
-    setSimulationState(state)
-    console.log('isSuccess', isSuccess)
-    if (!isSuccess && !override) return
+    if (!override) {
+      setSimulationState(TransactionReviewSimulationState.loading)
+      const isSuccess = await simulateTrade()
+      const state = isSuccess
+        ? TransactionReviewSimulationState.success
+        : TransactionReviewSimulationState.failure
+      setSimulationState(state)
+      if (!isSuccess) return
+    }
     const success = await makeTrade(override)
     if (success === null) return
     onSubmitWithSuccess(success)


### PR DESCRIPTION
## **Summary of Changes**

* Should fix overriding in transaction review by adding an additional check for not re-running simulations

## **Test Data or Screenshots**

* To test just `return false` in `simulateTrade` which simulates a failed tx simulation
* When getting a quote e.g. ETH-ETH2x and opening up the transaction review...
* Submitting should fail the simulation and show `override`
* Unchecked `override` should make the submit button disabled
* Checking `override` should let the user submit the tx nevertheless

```typescript
  async function simulateTrade(): Promise<boolean> {
    return false
...
```

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
