### PR TITLE
feat: add legacy redeem

### DIFF
--- a/src/app/legacy/components/redeem-widget/components/deposit-withdraw-selector.tsx
+++ b/src/app/legacy/components/redeem-widget/components/deposit-withdraw-selector.tsx
@@ -1,0 +1,62 @@
+import clsx from 'clsx'
+
+type BuySellSelectorProps = {
+  isDepositing: boolean
+  onClick: () => void
+}
+
+export function DepositWithdrawSelector({
+  isDepositing,
+  onClick,
+}: BuySellSelectorProps) {
+  return (
+    <div className='bg-ic-blue-950 flex flex-row rounded-md'>
+      <SelectorButton
+        isSelected={isDepositing === true}
+        label='Deposit'
+        roundedLeft={true}
+        onClick={onClick}
+      />
+      <SelectorButton
+        isSelected={isDepositing === false}
+        label='Withdraw'
+        roundedLeft={false}
+        onClick={onClick}
+      />
+    </div>
+  )
+}
+
+export function SelectorButton({
+  isSelected,
+  label,
+  roundedLeft,
+  onClick,
+}: {
+  isSelected: boolean
+  label: string
+  roundedLeft: boolean
+  onClick: () => void
+}) {
+  const textColor = isSelected ? 'text-ic-white' : 'text-ic-gray-500'
+  const bgColor = isSelected ? 'bg-ic-blue-600' : 'bg-ic-gray-800'
+  return (
+    <div
+      className={
+        'bg-ic-blue-950 flex-grow cursor-pointer select-none rounded-md'
+      }
+      onClick={onClick}
+    >
+      <div className={clsx('py-5 text-center text-sm font-bold', textColor)}>
+        {label}
+      </div>
+      <div
+        className={clsx(
+          'h-1 w-full',
+          bgColor,
+          roundedLeft ? 'rounded-bl-md' : 'rounded-br-md',
+        )}
+      ></div>
+    </div>
+  )
+}

--- a/src/app/legacy/components/redeem-widget/components/summary.tsx
+++ b/src/app/legacy/components/redeem-widget/components/summary.tsx
@@ -1,0 +1,97 @@
+import { Disclosure } from '@headlessui/react'
+import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/20/solid'
+
+import { GasFees } from '@/components/gas-fees'
+import { StyledSkeleton } from '@/components/skeleton'
+
+import { useFormattedData } from '../use-formatted-data'
+
+type SummaryQuoteProps = {
+  label: string
+  value: string
+  valueUsd: string
+}
+
+function SummaryQuote(props: SummaryQuoteProps) {
+  return (
+    <div className='text-ic-gray-300 flex flex-row items-center justify-between text-xs'>
+      <div className='font-medium'>{props.label}</div>
+      <div className='flex flex-row gap-1'>
+        <div className='text-ic-white font-bold'>{props.value}</div>
+        <div className='font-normal'>{props.valueUsd}</div>
+      </div>
+    </div>
+  )
+}
+
+export function Summary() {
+  const {
+    gasFeesEth,
+    gasFeesUsd,
+    inputAmount,
+    inputAmoutUsd,
+    isFetchingQuote,
+    ouputAmount,
+    outputAmountUsd,
+    shouldShowSummaryDetails,
+  } = useFormattedData()
+  if (!shouldShowSummaryDetails && !isFetchingQuote) return null
+  return (
+    <Disclosure as='div' className='rounded-xl border border-[#3A6060]'>
+      {({ open }) => (
+        <div className='p-4'>
+          <dt>
+            <Disclosure.Button className='text-ic-gray-300 flex w-full items-center justify-between text-left'>
+              <span className='text-xs font-medium'>
+                {open && 'Summary'}
+                {!open && isFetchingQuote && <StyledSkeleton width={120} />}
+                {!open &&
+                  !isFetchingQuote &&
+                  shouldShowSummaryDetails &&
+                  `Receive ${ouputAmount}`}
+              </span>
+              <div className='flex flex-row items-center gap-1'>
+                {!open && !isFetchingQuote ? (
+                  <GasFees
+                    valueUsd={gasFeesUsd}
+                    styles={{ valueUsdTextColor: 'text-ic-gray-300' }}
+                  />
+                ) : null}
+                {!open && isFetchingQuote && <StyledSkeleton width={70} />}
+                <span className='flex items-center'>
+                  {open ? (
+                    <ChevronUpIcon className='h-6 w-6' aria-hidden='true' />
+                  ) : (
+                    <ChevronDownIcon className='h-6 w-6' aria-hidden='true' />
+                  )}
+                </span>
+              </div>
+            </Disclosure.Button>
+          </dt>
+          <Disclosure.Panel as='dd' className='mt-2 flex flex-col gap-2'>
+            {shouldShowSummaryDetails && (
+              <>
+                <SummaryQuote
+                  label='Pay'
+                  value={inputAmount}
+                  valueUsd={`(${inputAmoutUsd})`}
+                />
+                <SummaryQuote
+                  label='Receive'
+                  value={ouputAmount}
+                  valueUsd={`(${outputAmountUsd})`}
+                />
+                <div className='text-ic-gray-300 flex flex-row items-center justify-between text-xs'>
+                  <div className='font-normal'>Network Fee</div>
+                  <div>
+                    <GasFees valueUsd={gasFeesUsd} value={gasFeesEth} />
+                  </div>
+                </div>
+              </>
+            )}
+          </Disclosure.Panel>
+        </div>
+      )}
+    </Disclosure>
+  )
+}

--- a/src/app/legacy/components/redeem-widget/components/title-logo.tsx
+++ b/src/app/legacy/components/redeem-widget/components/title-logo.tsx
@@ -1,0 +1,22 @@
+import Image from 'next/image'
+
+type TitleLogoProps = {
+  logo: string
+  symbol: string
+}
+
+export function TitleLogo({ logo, symbol }: TitleLogoProps) {
+  return (
+    <div className='text-ic-white flex flex-1 self-center text-base font-bold'>
+      <div className='my-auto mr-2 overflow-hidden rounded-full'>
+        <Image
+          src={logo ?? '/assets/index-token.png'}
+          alt={`${symbol} logo`}
+          height={28}
+          width={28}
+        />
+      </div>
+      {symbol}
+    </div>
+  )
+}

--- a/src/app/legacy/components/redeem-widget/index.tsx
+++ b/src/app/legacy/components/redeem-widget/index.tsx
@@ -1,0 +1,175 @@
+'use client'
+
+import { useCallback, useMemo } from 'react'
+import { formatUnits } from 'viem'
+
+import { useDisclosure } from '@chakra-ui/react'
+import { useConnectModal } from '@rainbow-me/rainbowkit'
+
+import { TradeInputSelector } from '@/components/swap/components/trade-input-selector'
+import { TransactionReviewModal } from '@/components/swap/components/transaction-review'
+import { TransactionReview } from '@/components/swap/components/transaction-review/types'
+import { useApproval } from '@/lib/hooks/use-approval'
+import { useTradeButton } from '@/components/swap/hooks/use-trade-button'
+import {
+  TradeButtonState,
+  useTradeButtonState,
+} from '@/components/swap/hooks/use-trade-button-state'
+import { TradeButton } from '@/components/trade-button'
+import { QuoteType } from '@/lib/hooks/use-best-quote/types'
+
+import { useRedeem } from '../../providers/redeem-provider'
+
+import { DepositWithdrawSelector } from './components/deposit-withdraw-selector'
+import { Summary } from './components/summary'
+import { TitleLogo } from './components/title-logo'
+import { useFormattedData } from './use-formatted-data'
+
+import './styles.css'
+
+export function RedeemWidget() {
+  const { openConnectModal } = useConnectModal()
+  const {
+    inputValue,
+    inputToken,
+    inputTokenAmount,
+    isDepositing,
+    isFetchingQuote,
+    onChangeInputTokenAmount,
+    outputToken,
+    quoteResult,
+    reset,
+  } = useRedeem()
+  const {
+    hasInsufficientFunds,
+    inputAmoutUsd,
+    inputTokenBalance,
+    inputTokenBalanceFormatted,
+    forceRefetch,
+  } = useFormattedData()
+
+  const {
+    isApproved,
+    isApproving,
+    approve: onApprove,
+  } = useApproval(
+    inputToken,
+    '0x04b59F9F09750C044D7CfbC177561E409085f0f3',
+    inputTokenAmount,
+  )
+
+  const {
+    isOpen: isTransactionReviewOpen,
+    onOpen: onOpenTransactionReview,
+    onClose: onCloseTransactionReview,
+  } = useDisclosure()
+
+  const shouldApprove = true
+  const buttonState = useTradeButtonState(
+    false,
+    hasInsufficientFunds,
+    shouldApprove,
+    isApproved,
+    isApproving,
+    outputToken,
+    inputValue,
+  )
+  const { buttonLabel, isDisabled } = useTradeButton(buttonState)
+
+  const transactionReview = useMemo((): TransactionReview | null => {
+    if (isFetchingQuote || quoteResult === null) return null
+    const quote = quoteResult.quote
+    if (quote) {
+      return {
+        ...quote,
+        contractAddress: quote.contract,
+        quoteResults: {
+          bestQuote: QuoteType.issuance,
+          results: {
+            flashmint: null,
+            issuance: quoteResult,
+            redemption: null,
+            zeroex: null,
+          },
+        },
+        selectedQuote: QuoteType.issuance,
+      }
+    }
+    return null
+  }, [isFetchingQuote, quoteResult])
+
+  const onClickBalance = useCallback(() => {
+    if (!inputTokenBalance) return
+    onChangeInputTokenAmount(formatUnits(inputTokenBalance, 18))
+  }, [inputTokenBalance, onChangeInputTokenAmount])
+
+  const onClickButton = useCallback(async () => {
+    if (buttonState === TradeButtonState.connectWallet) {
+      if (openConnectModal) {
+        openConnectModal()
+      }
+      return
+    }
+
+    // if (buttonState === TradeButtonState.fetchingError) {
+    //   fetchOptions()
+    //   return
+    // }
+
+    if (buttonState === TradeButtonState.insufficientFunds) return
+
+    if (!isApproved && shouldApprove) {
+      await onApprove()
+      return
+    }
+
+    if (buttonState === TradeButtonState.default) {
+      onOpenTransactionReview()
+    }
+  }, [
+    buttonState,
+    isApproved,
+    onApprove,
+    onOpenTransactionReview,
+    openConnectModal,
+    shouldApprove,
+  ])
+
+  const onSelectToken = () => {}
+
+  return (
+    <div className='widget w-full min-w-80 flex-1 flex-col space-y-4 rounded-3xl p-6'>
+      <TitleLogo logo={inputToken.image ?? ''} symbol={inputToken.symbol} />
+      <DepositWithdrawSelector isDepositing={isDepositing} onClick={() => {}} />
+      <TradeInputSelector
+        config={{ isReadOnly: false }}
+        balance={inputTokenBalanceFormatted}
+        caption='You pay'
+        formattedFiat={inputAmoutUsd}
+        selectedToken={inputToken}
+        selectedTokenAmount={inputValue}
+        onChangeInput={(_, amount) => onChangeInputTokenAmount(amount)}
+        onClickBalance={onClickBalance}
+        onSelectToken={onSelectToken}
+      />
+      <Summary />
+      <TradeButton
+        label={buttonLabel}
+        isDisabled={isDisabled}
+        isLoading={isFetchingQuote}
+        onClick={onClickButton}
+      />
+      {transactionReview && (
+        <TransactionReviewModal
+          isOpen={isTransactionReviewOpen}
+          onClose={() => {
+            reset()
+            forceRefetch()
+            onCloseTransactionReview()
+          }}
+          transactionReview={transactionReview}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/app/legacy/components/redeem-widget/styles.css
+++ b/src/app/legacy/components/redeem-widget/styles.css
@@ -1,0 +1,18 @@
+.widget {
+  background: linear-gradient(
+      210deg,
+      rgba(243, 255, 239, 0.08) -24.93%,
+      rgba(255, 255, 255, 0) 145.44%
+    ),
+    linear-gradient(
+      51deg,
+      rgba(0, 189, 192, 0.15) -76.7%,
+      rgba(0, 249, 228, 0.15) -6.53%,
+      rgba(212, 0, 216, 0.15) 183.55%
+    ),
+    linear-gradient(195deg, #143438 -23.15%, #052629 227.79%);
+  border: 1px solid #006a71;
+  box-shadow:
+    0.5px 1px 2px 0px rgba(44, 51, 51, 0.25),
+    2px 2px 1px 0px rgba(5, 172, 175, 0.49) inset;
+}

--- a/src/app/legacy/components/redeem-widget/use-formatted-data.tsx
+++ b/src/app/legacy/components/redeem-widget/use-formatted-data.tsx
@@ -1,0 +1,73 @@
+import { useMemo } from 'react'
+import { formatUnits } from 'viem'
+
+import { useFormattedBalance } from '@/components/swap/hooks/use-swap/use-formatted-balance'
+import { useWallet } from '@/lib/hooks/use-wallet'
+import { formatAmount } from '@/lib/utils'
+
+import { useRedeem } from '../../providers/redeem-provider'
+
+export function useFormattedData() {
+  const { address } = useWallet()
+  const {
+    inputToken,
+    inputTokenAmount,
+    inputValue,
+    isFetchingQuote,
+    quoteResult,
+  } = useRedeem()
+  const {
+    balance,
+    balanceFormatted,
+    forceRefetch: forceRefetchPreSaleTokenBalance,
+  } = useFormattedBalance(inputToken, address)
+
+  const quote = useMemo(() => quoteResult?.quote ?? null, [quoteResult])
+
+  const inputAmount = quote?.inputTokenAmount
+    ? `${formatAmount(Number(formatUnits(quote?.inputTokenAmount.toBigInt(), quote?.inputToken.decimals)))} ${quote?.inputToken.symbol}`
+    : ''
+  const inputAmoutUsd = quote?.inputTokenAmountUsd
+    ? `$${formatAmount(quote?.inputTokenAmountUsd)}`
+    : ''
+
+  const hasInsufficientFunds = useMemo(
+    () => balance < inputTokenAmount,
+    [inputTokenAmount, balance],
+  )
+
+  const ouputAmount = quote?.outputTokenAmount
+    ? `${formatAmount(Number(formatUnits(quote?.outputTokenAmount.toBigInt(), quote?.outputToken.decimals)))} ${quote?.outputToken.symbol}`
+    : ''
+  const outputAmountUsd = quote?.outputTokenAmountUsd
+    ? `$${formatAmount(quote?.outputTokenAmountUsd)}`
+    : ''
+
+  const shouldShowSummaryDetails = useMemo(
+    () => quote !== null && inputValue !== '',
+    [inputValue, quote],
+  )
+
+  const forceRefetch = () => {
+    forceRefetchPreSaleTokenBalance()
+  }
+
+  return {
+    hasInsufficientFunds,
+    gasFeesEth: quote?.gasCosts
+      ? `(${formatUnits(quote.gasCosts.toBigInt(), 18)} ETH)`
+      : '',
+    gasFeesUsd: quote?.gasCostsInUsd
+      ? `$${formatAmount(quote.gasCostsInUsd)}`
+      : '',
+    inputAmount,
+    inputAmoutUsd,
+    inputTokenBalance: balance,
+    inputTokenBalanceFormatted: balanceFormatted,
+    isFetchingQuote,
+    ouputAmount,
+    outputAmountUsd,
+    shouldShowSummaryDetails,
+    forceRefetch,
+  }
+}

--- a/src/app/legacy/layout.tsx
+++ b/src/app/legacy/layout.tsx
@@ -1,0 +1,20 @@
+import { Footer } from '@/components/footer'
+import { Header } from '@/components/header'
+
+import { Providers } from '@/app/providers'
+
+type Props = {
+  children: React.ReactNode
+}
+
+export default function Layout({ children }: Props) {
+  return (
+    <div className="flex h-fit flex-col bg-[url('/presale-splash.jpg')] bg-cover">
+      <Providers>
+        <Header />
+        <main>{children}</main>
+        <Footer />
+      </Providers>
+    </div>
+  )
+}

--- a/src/app/legacy/page.tsx
+++ b/src/app/legacy/page.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { RedeemWidget } from './components/redeem-widget'
+import { RedeemProvider } from './providers/redeem-provider'
+
+export default function Page() {
+  return (
+    <div className='mx-auto max-w-xl px-4 py-16'>
+      <div className='w-full'>
+        <RedeemProvider>
+          <RedeemWidget />
+        </RedeemProvider>
+      </div>
+    </div>
+  )
+}

--- a/src/app/legacy/providers/redeem-provider.tsx
+++ b/src/app/legacy/providers/redeem-provider.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react'
 import { usePublicClient } from 'wagmi'
 
-import { ETH, LeveragedRethStakingYield, Token } from '@/constants/tokens'
+import { LeveragedRethStakingYield, RETH, Token } from '@/constants/tokens'
 import { getEnhancedIssuanceQuote } from '@/lib/hooks/use-best-quote/utils/issuance'
 import { QuoteResult, QuoteType } from '@/lib/hooks/use-best-quote/types'
 import { getTokenPrice, useNativeTokenPrice } from '@/lib/hooks/use-token-price'
@@ -32,7 +32,7 @@ const RedeemContext = createContext<RedeemContextProps>({
   isDepositing: false,
   isFetchingQuote: false,
   inputToken: LeveragedRethStakingYield,
-  outputToken: ETH,
+  outputToken: RETH,
   inputTokenAmount: BigInt(0),
   quoteResult: null,
   onChangeInputTokenAmount: () => {},
@@ -47,7 +47,7 @@ export function RedeemProvider(props: { children: any }) {
   const { address, provider } = useWallet()
 
   const isDepositing = false
-  const currencyToken = ETH
+  const currencyToken = RETH
   const indexToken = LeveragedRethStakingYield
 
   const [inputValue, setInputValue] = useState('')

--- a/src/app/legacy/providers/redeem-provider.tsx
+++ b/src/app/legacy/providers/redeem-provider.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react'
 import { usePublicClient } from 'wagmi'
 
-import { ETH, RETH, Token } from '@/constants/tokens'
+import { ETH, LeveragedRethStakingYield, Token } from '@/constants/tokens'
 import { getEnhancedIssuanceQuote } from '@/lib/hooks/use-best-quote/utils/issuance'
 import { QuoteResult, QuoteType } from '@/lib/hooks/use-best-quote/types'
 import { getTokenPrice, useNativeTokenPrice } from '@/lib/hooks/use-token-price'
@@ -31,7 +31,7 @@ const RedeemContext = createContext<RedeemContextProps>({
   inputValue: '',
   isDepositing: false,
   isFetchingQuote: false,
-  inputToken: RETH,
+  inputToken: LeveragedRethStakingYield,
   outputToken: ETH,
   inputTokenAmount: BigInt(0),
   quoteResult: null,
@@ -48,7 +48,7 @@ export function RedeemProvider(props: { children: any }) {
 
   const isDepositing = false
   const currencyToken = ETH
-  const indexToken = RETH
+  const indexToken = LeveragedRethStakingYield
 
   const [inputValue, setInputValue] = useState('')
   const [isFetchingQuote, setFetchingQuote] = useState(false)

--- a/src/app/legacy/providers/redeem-provider.tsx
+++ b/src/app/legacy/providers/redeem-provider.tsx
@@ -1,0 +1,164 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+import { usePublicClient } from 'wagmi'
+
+import { ETH, RETH, Token } from '@/constants/tokens'
+import { getEnhancedIssuanceQuote } from '@/lib/hooks/use-best-quote/utils/issuance'
+import { QuoteResult, QuoteType } from '@/lib/hooks/use-best-quote/types'
+import { getTokenPrice, useNativeTokenPrice } from '@/lib/hooks/use-token-price'
+import { useWallet } from '@/lib/hooks/use-wallet'
+import { isValidTokenInput, toWei } from '@/lib/utils'
+
+interface RedeemContextProps {
+  inputValue: string
+  isDepositing: boolean
+  isFetchingQuote: boolean
+  inputToken: Token
+  outputToken: Token
+  inputTokenAmount: bigint
+  quoteResult: QuoteResult | null
+  onChangeInputTokenAmount: (input: string) => void
+  reset: () => void
+}
+
+const RedeemContext = createContext<RedeemContextProps>({
+  inputValue: '',
+  isDepositing: false,
+  isFetchingQuote: false,
+  inputToken: RETH,
+  outputToken: ETH,
+  inputTokenAmount: BigInt(0),
+  quoteResult: null,
+  onChangeInputTokenAmount: () => {},
+  reset: () => {},
+})
+
+export const useRedeem = () => useContext(RedeemContext)
+
+export function RedeemProvider(props: { children: any }) {
+  const nativeTokenPrice = useNativeTokenPrice(1)
+  const publicClient = usePublicClient()
+  const { address, provider } = useWallet()
+
+  const isDepositing = false
+  const currencyToken = ETH
+  const indexToken = RETH
+
+  const [inputValue, setInputValue] = useState('')
+  const [isFetchingQuote, setFetchingQuote] = useState(false)
+  const [quoteResult, setQuoteResult] = useState<QuoteResult>({
+    type: QuoteType.issuance,
+    isAvailable: true,
+    quote: null,
+    error: null,
+  })
+
+  const inputToken = useMemo(
+    () => (isDepositing ? currencyToken : indexToken),
+    [isDepositing, currencyToken, indexToken],
+  )
+
+  const inputTokenAmount = useMemo(
+    () =>
+      inputValue === ''
+        ? BigInt(0)
+        : toWei(inputValue, inputToken.decimals).toBigInt(),
+    [inputToken, inputValue],
+  )
+
+  const outputToken = useMemo(
+    () => (isDepositing ? indexToken : currencyToken),
+    [isDepositing, currencyToken, indexToken],
+  )
+
+  const onChangeInputTokenAmount = useCallback(
+    (input: string) => {
+      if (input === '') {
+        setInputValue('')
+        return
+      }
+      if (!isValidTokenInput(input, inputToken.decimals)) return
+      setInputValue(input || '')
+    },
+    [inputToken],
+  )
+
+  const reset = () => {
+    setInputValue('')
+    setQuoteResult({
+      type: QuoteType.issuance,
+      isAvailable: true,
+      quote: null,
+      error: null,
+    })
+  }
+
+  useEffect(() => {
+    const fetchQuote = async () => {
+      if (!address) return
+      if (inputTokenAmount <= 0) return
+      setFetchingQuote(true)
+      const outputToken = isDepositing ? indexToken : currencyToken
+      const inputTokenPrice = await getTokenPrice(inputToken, 1)
+      const outputTokenPrice = await getTokenPrice(outputToken, 1)
+      const gasPrice = await provider.getGasPrice()
+      const quoteIssuance = await getEnhancedIssuanceQuote(
+        {
+          account: address,
+          isIssuance: isDepositing,
+          gasPrice,
+          inputTokenAmount,
+          inputToken,
+          inputTokenPrice,
+          outputToken,
+          outputTokenPrice,
+          nativeTokenPrice,
+          slippage: 0,
+        },
+        publicClient,
+      )
+      setFetchingQuote(false)
+      setQuoteResult({
+        type: QuoteType.issuance,
+        isAvailable: true,
+        quote: quoteIssuance,
+        error: null,
+      })
+    }
+    fetchQuote()
+  }, [
+    address,
+    currencyToken,
+    indexToken,
+    inputToken,
+    inputTokenAmount,
+    isDepositing,
+    nativeTokenPrice,
+    provider,
+    publicClient,
+  ])
+
+  return (
+    <RedeemContext.Provider
+      value={{
+        inputValue,
+        isDepositing,
+        isFetchingQuote,
+        inputToken,
+        outputToken,
+        inputTokenAmount,
+        quoteResult,
+        onChangeInputTokenAmount,
+        reset,
+      }}
+    >
+      {props.children}
+    </RedeemContext.Provider>
+  )
+}

--- a/src/lib/utils/tokens.ts
+++ b/src/lib/utils/tokens.ts
@@ -132,7 +132,8 @@ export function isAvailableForIssuance(
 ): boolean {
   return (
     inputToken.symbol === HighYieldETHIndex.symbol ||
-    outputToken.symbol === HighYieldETHIndex.symbol
+    outputToken.symbol === HighYieldETHIndex.symbol ||
+    inputToken.symbol === LeveragedRethStakingYield.symbol
   )
 }
 


### PR DESCRIPTION
## **Summary of Changes**

* Adds a simple page for redeeming legacy products ([/legacy](https://index-app-git-feat-add-legacy-redeem-index-coop.vercel.app/legacy)) - currently hard-coded to icRETH

## **Test Data or Screenshots**
<img width="965" alt="Bildschirmfoto 2024-04-04 um 09 13 18" src="https://github.com/IndexCoop/index-app/assets/2104965/d629c7b9-3b6f-45af-bfb2-a33ff59158a4">

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
