### PR TITLE
add banner

### DIFF
--- a/src/app/swap/layout.tsx
+++ b/src/app/swap/layout.tsx
@@ -1,5 +1,6 @@
 import { Flex } from '@chakra-ui/react'
 
+import { Banner } from '@/components/banners'
 import { Footer } from '@/components/footer'
 import { Header } from '@/components/header'
 
@@ -12,7 +13,7 @@ type LayoutProps = {
 export default function Layout({ children }: LayoutProps) {
   return (
     <Providers>
-      {/* <Banner /> */}
+      <Banner />
       <Header />
       <Flex direction='column' mb='50px'>
         <Flex maxWidth='1024px' m={['0 auto']} p='60px 16px 0px 16px'>

--- a/src/components/banners/index.tsx
+++ b/src/components/banners/index.tsx
@@ -1,14 +1,23 @@
-
 export function Banner() {
   return (
     <div className='flex justify-center bg-[#006A71] p-3'>
       <p className='text-ic-white text-sm font-semibold'>
-        We are experiencing some temporary downtime for swaps via our app. To
-        swap our tokens please visit{' '}
-        <a className='underline' href='https://swap.cow.fi/' target='_blank'>
-          https://swap.cow.fi/
+        DPI and MVI are coming to Arbitrum.{' '}
+        <a
+          className='underline'
+          href='https://app.transporter.io/?from=mainnet&to=arbitrum'
+          target='_blank'
+        >
+          Bridge
+        </a>{' '}
+        your Tokens now to earn Arb rewards.{' '}
+        <a
+          className='underline'
+          href='https://indexcoop.com/blog/dpi-and-mvi-on-arbitrum-faq'
+          target='_blank'
+        >
+          Learn more
         </a>
-        . Flash Minting is not affected.
       </p>
     </div>
   )


### PR DESCRIPTION
## **Summary of Changes**

* Adds banner to advertise bridging MVI and DPI to Arbitrum

## **Test Data or Screenshots**

<img width="1512" alt="Bildschirmfoto 2024-05-08 um 11 31 35" src="https://github.com/IndexCoop/index-app/assets/2104965/3100f7a4-8815-4a6b-bf6a-dd51e564ecf0">


###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
