### PR TITLE
feat: add gtceth and bed to legacy redeem

### DIFF
--- a/src/app/legacy/components/redeem-widget/index.tsx
+++ b/src/app/legacy/components/redeem-widget/index.tsx
@@ -4,6 +4,7 @@ import { useDisclosure } from '@chakra-ui/react'
 import { useChainModal, useConnectModal } from '@rainbow-me/rainbowkit'
 import { useCallback, useMemo } from 'react'
 
+import { SelectTokenModal } from '@/components/swap/components/select-token-modal'
 import { TradeInputSelector } from '@/components/swap/components/trade-input-selector'
 import { TransactionReviewModal } from '@/components/swap/components/transaction-review'
 import { TransactionReview } from '@/components/swap/components/transaction-review/types'
@@ -16,6 +17,7 @@ import { TradeButton } from '@/components/trade-button'
 import { useApproval } from '@/lib/hooks/use-approval'
 import { QuoteType } from '@/lib/hooks/use-best-quote/types'
 import { useMainnetOnly } from '@/lib/hooks/use-network'
+import { useWallet } from '@/lib/hooks/use-wallet'
 import { useSignTerms } from '@/lib/providers/sign-terms-provider'
 import { formatWei } from '@/lib/utils'
 
@@ -32,14 +34,17 @@ export function RedeemWidget() {
   const isSupportedNetwork = useMainnetOnly()
   const { openChainModal } = useChainModal()
   const { signTermsOfService } = useSignTerms()
+  const { address } = useWallet()
   const { openConnectModal } = useConnectModal()
   const {
+    inputTokenList,
     inputValue,
     inputToken,
     inputTokenAmount,
     isDepositing,
     isFetchingQuote,
     onChangeInputTokenAmount,
+    onSelectInputToken,
     outputToken,
     quoteResult,
     reset,
@@ -62,6 +67,11 @@ export function RedeemWidget() {
     inputTokenAmount,
   )
 
+  const {
+    isOpen: isSelectInputTokenOpen,
+    onOpen: onOpenSelectInputToken,
+    onClose: onCloseSelectInputToken,
+  } = useDisclosure()
   const {
     isOpen: isTransactionReviewOpen,
     onOpen: onOpenTransactionReview,
@@ -154,8 +164,6 @@ export function RedeemWidget() {
     shouldApprove,
   ])
 
-  const onSelectToken = () => {}
-
   return (
     <div className='widget w-full min-w-80 flex-1 flex-col space-y-4 rounded-3xl p-6'>
       <TitleLogo logo={inputToken.image ?? ''} symbol={inputToken.symbol} />
@@ -169,7 +177,7 @@ export function RedeemWidget() {
         selectedTokenAmount={inputValue}
         onChangeInput={(_, amount) => onChangeInputTokenAmount(amount)}
         onClickBalance={onClickBalance}
-        onSelectToken={onSelectToken}
+        onSelectToken={onOpenSelectInputToken}
       />
       <Summary />
       <TradeButton
@@ -177,6 +185,18 @@ export function RedeemWidget() {
         isDisabled={isDisabled}
         isLoading={isFetchingQuote}
         onClick={onClickButton}
+      />
+      <SelectTokenModal
+        isDarkMode={true}
+        isOpen={isSelectInputTokenOpen}
+        showBalances={false}
+        onClose={onCloseSelectInputToken}
+        onSelectedToken={(tokenSymbol) => {
+          onSelectInputToken(tokenSymbol)
+          onCloseSelectInputToken()
+        }}
+        address={address}
+        tokens={inputTokenList}
       />
       {transactionReview && (
         <TransactionReviewModal

--- a/src/app/legacy/providers/redeem-provider.tsx
+++ b/src/app/legacy/providers/redeem-provider.tsx
@@ -8,14 +8,23 @@ import {
 } from 'react'
 import { usePublicClient } from 'wagmi'
 
-import { LeveragedRethStakingYield, RETH, Token } from '@/constants/tokens'
+import {
+  BedIndex,
+  GitcoinStakedETHIndex,
+  LeveragedRethStakingYield,
+  RETH,
+  Token,
+} from '@/constants/tokens'
 import { QuoteResult, QuoteType } from '@/lib/hooks/use-best-quote/types'
 import { getEnhancedIssuanceQuote } from '@/lib/hooks/use-best-quote/utils/issuance'
 import { getTokenPrice, useNativeTokenPrice } from '@/lib/hooks/use-token-price'
 import { useWallet } from '@/lib/hooks/use-wallet'
 import { isValidTokenInput, toWei } from '@/lib/utils'
 
+export const inputTokenList = [GitcoinStakedETHIndex, RETH, BedIndex]
+
 interface RedeemContextProps {
+  inputTokenList: Token[]
   inputValue: string
   isDepositing: boolean
   isFetchingQuote: boolean
@@ -24,10 +33,12 @@ interface RedeemContextProps {
   inputTokenAmount: bigint
   quoteResult: QuoteResult | null
   onChangeInputTokenAmount: (input: string) => void
+  onSelectInputToken: (tokenSymbol: string) => void
   reset: () => void
 }
 
 const RedeemContext = createContext<RedeemContextProps>({
+  inputTokenList,
   inputValue: '',
   isDepositing: false,
   isFetchingQuote: false,
@@ -36,6 +47,7 @@ const RedeemContext = createContext<RedeemContextProps>({
   inputTokenAmount: BigInt(0),
   quoteResult: null,
   onChangeInputTokenAmount: () => {},
+  onSelectInputToken: () => {},
   reset: () => {},
 })
 
@@ -50,6 +62,7 @@ export function RedeemProvider(props: { children: any }) {
   const currencyToken = RETH
   const indexToken = LeveragedRethStakingYield
 
+  const [inputToken, setInputToken] = useState(inputTokenList[0])
   const [inputValue, setInputValue] = useState('')
   const [isFetchingQuote, setFetchingQuote] = useState(false)
   const [quoteResult, setQuoteResult] = useState<QuoteResult>({
@@ -58,11 +71,6 @@ export function RedeemProvider(props: { children: any }) {
     quote: null,
     error: null,
   })
-
-  const inputToken = useMemo(
-    () => (isDepositing ? currencyToken : indexToken),
-    [isDepositing, currencyToken, indexToken],
-  )
 
   const inputTokenAmount = useMemo(
     () =>
@@ -88,6 +96,12 @@ export function RedeemProvider(props: { children: any }) {
     },
     [inputToken],
   )
+
+  const onSelectInputToken = useCallback((tokenSymbol: string) => {
+    const token = inputTokenList.find((token) => token.symbol === tokenSymbol)
+    if (!token) return
+    setInputToken(token)
+  }, [])
 
   const reset = () => {
     setInputValue('')
@@ -148,6 +162,7 @@ export function RedeemProvider(props: { children: any }) {
   return (
     <RedeemContext.Provider
       value={{
+        inputTokenList,
         inputValue,
         isDepositing,
         isFetchingQuote,
@@ -156,6 +171,7 @@ export function RedeemProvider(props: { children: any }) {
         inputTokenAmount,
         quoteResult,
         onChangeInputTokenAmount,
+        onSelectInputToken,
         reset,
       }}
     >

--- a/src/app/legacy/providers/redeem-provider.tsx
+++ b/src/app/legacy/providers/redeem-provider.tsx
@@ -21,7 +21,11 @@ import { getTokenPrice, useNativeTokenPrice } from '@/lib/hooks/use-token-price'
 import { useWallet } from '@/lib/hooks/use-wallet'
 import { isValidTokenInput, toWei } from '@/lib/utils'
 
-export const inputTokenList = [GitcoinStakedETHIndex, RETH, BedIndex]
+export const inputTokenList = [
+  GitcoinStakedETHIndex,
+  LeveragedRethStakingYield,
+  BedIndex,
+]
 
 interface RedeemContextProps {
   inputTokenList: Token[]

--- a/src/lib/hooks/use-best-quote/utils/issuance/issuance-quote.ts
+++ b/src/lib/hooks/use-best-quote/utils/issuance/issuance-quote.ts
@@ -1,7 +1,8 @@
+import { getIssuanceModule } from '@indexcoop/flash-mint-sdk'
 import { BigNumber } from 'ethers'
 import { Address, encodeFunctionData, PublicClient } from 'viem'
 
-import { Token } from '@/constants/tokens'
+import { BedIndex, LeveragedRethStakingYield, Token } from '@/constants/tokens'
 import { formatWei } from '@/lib/utils'
 import { getFullCostsInUsd, getGasCostsInUsd } from '@/lib/utils/costs'
 import { getFlashMintGasDefault } from '@/lib/utils/gas-defaults'
@@ -30,7 +31,6 @@ export async function getEnhancedIssuanceQuote(
   request: IssuanceQuoteRequest,
   publicClient: PublicClient,
 ): Promise<Quote | null> {
-  const contract = '0x04b59F9F09750C044D7CfbC177561E409085f0f3'
   const {
     account,
     isIssuance,
@@ -42,6 +42,16 @@ export async function getEnhancedIssuanceQuote(
     outputToken,
     outputTokenPrice,
   } = request
+
+  const chainId = 1
+  let contract = getIssuanceModule(inputToken.symbol, chainId)
+    .address as Address
+  if (
+    BedIndex.symbol === inputToken.symbol ||
+    LeveragedRethStakingYield.symbol === inputToken.symbol
+  ) {
+    contract = '0x04b59F9F09750C044D7CfbC177561E409085f0f3'
+  }
 
   if (!isAvailableForIssuance(inputToken, outputToken)) return null
   if (inputTokenAmount <= 0) return null

--- a/src/lib/utils/tokens.ts
+++ b/src/lib/utils/tokens.ts
@@ -3,6 +3,7 @@ import { IndexCoopInverseEthereumIndex } from '@indexcoop/flash-mint-sdk'
 import { ARBITRUM, MAINNET, OPTIMISM, POLYGON } from '@/constants/chains'
 import { currencies, indicesTokenList } from '@/constants/tokenlists'
 import {
+  BedIndex,
   Bitcoin2xFlexibleLeverageIndex,
   CoinDeskEthTrendIndex,
   DAI,
@@ -145,6 +146,8 @@ export function isAvailableForIssuance(
   outputToken: Token,
 ): boolean {
   return (
+    inputToken.symbol === BedIndex.symbol ||
+    inputToken.symbol === GitcoinStakedETHIndex.symbol ||
     inputToken.symbol === HighYieldETHIndex.symbol ||
     outputToken.symbol === HighYieldETHIndex.symbol ||
     inputToken.symbol === LeveragedRethStakingYield.symbol


### PR DESCRIPTION
## **Summary of Changes**

* Adds `gtcETH` and `BED` to legacy redeem to provide an alternative path for users to redeem those products
* Adds select token modal to legacy widget (before it was only one token)

## **Test Data or Screenshots**
<img width="1512" alt="Bildschirmfoto 2024-05-10 um 16 37 02" src="https://github.com/IndexCoop/index-app/assets/2104965/289a4c3a-6dab-4392-8856-e5e47a394382">

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
