### PR TITLE
fix: Hidden warnings rendering

### DIFF
--- a/src/app/leverage/components/leverage-widget/index.tsx
+++ b/src/app/leverage/components/leverage-widget/index.tsx
@@ -25,6 +25,8 @@ import { Summary } from './components/summary'
 
 import './styles.css'
 
+const hiddenLeverageWarnings = [WarningType.flashbots]
+
 type LeverageWidgetProps = {
   onClickBaseTokenSelector: () => void
 }
@@ -122,7 +124,7 @@ export function LeverageWidget(props: LeverageWidgetProps) {
         contract={contract ?? ''}
         hasFetchingError={false}
         hasInsufficientFunds={hasInsufficientFunds}
-        hiddenWarnings={[WarningType.flashbots]}
+        hiddenWarnings={hiddenLeverageWarnings}
         inputTokenAmount={inputTokenAmount}
         inputToken={inputToken}
         inputValue={inputValue}

--- a/src/components/smart-trade-button/index.tsx
+++ b/src/components/smart-trade-button/index.tsx
@@ -38,7 +38,7 @@ export function SmartTradeButton(props: SmartTradeButtonProps) {
     contract,
     hasFetchingError,
     hasInsufficientFunds,
-    hiddenWarnings = [],
+    hiddenWarnings,
     inputTokenAmount,
     inputToken,
     inputValue,
@@ -91,22 +91,22 @@ export function SmartTradeButton(props: SmartTradeButtonProps) {
   const [warnings, setWarnings] = useState<WarningType[]>([])
 
   useEffect(() => {
-    if (!isTradablePair && !hiddenWarnings.includes(WarningType.restricted)) {
+    if (!isTradablePair && !hiddenWarnings?.includes(WarningType.restricted)) {
       setWarnings([WarningType.restricted])
       return
     }
     if (
       buttonState === TradeButtonState.signTerms &&
-      !hiddenWarnings.includes(WarningType.signTerms)
+      !hiddenWarnings?.includes(WarningType.signTerms)
     ) {
       setWarnings([WarningType.signTerms])
       return
     }
-    if (slippage > 9 && !hiddenWarnings.includes(WarningType.priceImpact)) {
+    if (slippage > 9 && !hiddenWarnings?.includes(WarningType.priceImpact)) {
       setWarnings([WarningType.priceImpact])
       return
     }
-    if (!hiddenWarnings.includes(WarningType.flashbots)) {
+    if (!hiddenWarnings?.includes(WarningType.flashbots)) {
       setWarnings([WarningType.flashbots])
     }
   }, [buttonState, hiddenWarnings, isTradablePair, slippage])


### PR DESCRIPTION
## **Summary of Changes**

Hidden warnings is triggering a re-render that interrupting other cycles. 

## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
