### PR TITLE
fix: Reset warnings if none set

### DIFF
--- a/src/components/smart-trade-button/index.tsx
+++ b/src/components/smart-trade-button/index.tsx
@@ -108,7 +108,9 @@ export function SmartTradeButton(props: SmartTradeButtonProps) {
     }
     if (!hiddenWarnings?.includes(WarningType.flashbots)) {
       setWarnings([WarningType.flashbots])
+      return
     }
+    setWarnings([])
   }, [buttonState, hiddenWarnings, isTradablePair, slippage])
 
   const onClick = useCallback(async () => {


### PR DESCRIPTION
## **Summary of Changes**

Fixes an issue where a warning set doesn't get removed on the leverage interface.

<img width="367" alt="image" src="https://github.com/IndexCoop/index-app/assets/136734776/ba9279c3-a472-45b2-b54a-6ab64b4e1b72">
 

## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
