### PR TITLE
feat: improve balance formatting

### DIFF
--- a/src/components/swap/hooks/use-swap/formatters/index.ts
+++ b/src/components/swap/hooks/use-swap/formatters/index.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber'
 
 import { Token } from '@/constants/tokens'
-import { displayFromWei, formatAmount } from '@/lib/utils'
+import { formatAmount, formatWei } from '@/lib/utils'
 
 import { TradeDetailTokenPrices } from '../../../components/trade-details'
 
@@ -13,9 +13,12 @@ export function formattedBalance(
   tokenBalance: BigNumber | undefined,
 ) {
   const zero = '0.00'
-  return tokenBalance
-    ? displayFromWei(tokenBalance, 2, token.decimals) || zero
-    : zero
+  if (!tokenBalance) return zero
+  const formattedBalance = Number(
+    formatWei(tokenBalance.toBigInt(), token.decimals),
+  )
+  const formatted = formatAmount(formattedBalance, 3)
+  return formatted
 }
 
 export function getFormattedTokenPrice(

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -31,10 +31,10 @@ export function shortenAddress(
   return `${shortenedStart}...${shortenedEnd}`
 }
 
-export const formatAmount = (amount: number) =>
+export const formatAmount = (amount: number, digits: number = 2) =>
   amount.toLocaleString('en-US', {
-    maximumFractionDigits: 2,
-    minimumFractionDigits: 2,
+    maximumFractionDigits: digits,
+    minimumFractionDigits: digits,
   })
 
 export function formatWei(wei: bigint, units: number = 18): string {

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -84,17 +84,6 @@ export const toWei = (
 }
 
 /**
- * Converts a number from Wei to another denomination of Eth
- * @param number
- * @param power default = 18
- * @returns
- */
-export const fromWei = (number?: BigNumber, power: number = 18): BigNumber => {
-  if (!number) return BigNumber.from(0)
-  return number.div(BigNumber.from(10).pow(power))
-}
-
-/**
  * Formats a BigNumber from Wei
  * @param decimals round to decimals is NOT precise
  * @param power default to 18 covers most token decimals


### PR DESCRIPTION
## **Summary of Changes**

* Updates balance decimals to be `3` for a better display of smaller numbers
* Removes obsolete wei utility function

## **Test Data or Screenshots**
<img width="555" alt="Bildschirmfoto 2024-06-14 um 11 12 30" src="https://github.com/IndexCoop/index-app/assets/2104965/f96f9a52-9d39-49a5-ac51-397e5bf42640">

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
