### PR TITLE
feat: PRT query param

### DIFF
--- a/src/app/presales/components/pre-sale-widget/use-formatted-data.tsx
+++ b/src/app/presales/components/pre-sale-widget/use-formatted-data.tsx
@@ -30,7 +30,10 @@ export function useFormattedData() {
     forceRefetch: forceRefetchPreSaleCurrencyTokenBalance,
   } = useFormattedBalance(preSaleCurrencyToken, address)
   const { formatted } = usePresaleData(preSaleToken.symbol)
-  const { earnedRewards, refetch: refetchRewards } = usePrtRewards(address)
+  const { earnedRewards, refetch: refetchRewards } = usePrtRewards(
+    address,
+    preSaleToken.address,
+  )
 
   const quote = useMemo(() => quoteResult?.quote ?? null, [quoteResult])
 

--- a/src/app/presales/components/pre-sale-widget/use-rewards.tsx
+++ b/src/app/presales/components/pre-sale-widget/use-rewards.tsx
@@ -20,7 +20,6 @@ export function usePrtRewards(
       const res = await indexApi.get(
         `/prts/${address}?tokenAddress=${tokenAddress}`,
       )
-      //   const formattedRewards = formatAmount(Number(res.reward_earned))
       setEarnedRewards(res.cumulative_rewards)
     } catch (err) {
       console.log('Error fetching prt rewards', err)

--- a/src/app/presales/components/pre-sale-widget/use-rewards.tsx
+++ b/src/app/presales/components/pre-sale-widget/use-rewards.tsx
@@ -11,14 +11,14 @@ export function usePrtRewards(
   const [earnedRewards, setEarnedRewards] = useState(earnedRewardsDefault)
 
   const fetchRewards = useCallback(async () => {
-    if (!address) {
+    if (!address || !tokenAddress) {
       setEarnedRewards(earnedRewardsDefault)
       return
     }
     try {
       const indexApi = new IndexApi()
       const res = await indexApi.get(
-        `/prts/${address}?tokenAddress=${tokenAddress ?? ''}`,
+        `/prts/${address}?tokenAddress=${tokenAddress}`,
       )
       //   const formattedRewards = formatAmount(Number(res.reward_earned))
       setEarnedRewards(res.cumulative_rewards)

--- a/src/app/presales/components/pre-sale-widget/use-rewards.tsx
+++ b/src/app/presales/components/pre-sale-widget/use-rewards.tsx
@@ -4,7 +4,10 @@ import { IndexApi } from '@/lib/utils/api/index-api'
 
 const earnedRewardsDefault = '0'
 
-export function usePrtRewards(address: string | undefined) {
+export function usePrtRewards(
+  address: string | undefined,
+  tokenAddress: string | undefined,
+) {
   const [earnedRewards, setEarnedRewards] = useState(earnedRewardsDefault)
 
   const fetchRewards = useCallback(async () => {
@@ -14,13 +17,15 @@ export function usePrtRewards(address: string | undefined) {
     }
     try {
       const indexApi = new IndexApi()
-      const res = await indexApi.get(`/prts/${address}`)
+      const res = await indexApi.get(
+        `/prts/${address}?tokenAddress=${tokenAddress ?? ''}`,
+      )
       //   const formattedRewards = formatAmount(Number(res.reward_earned))
       setEarnedRewards(res.cumulative_rewards)
     } catch (err) {
       console.log('Error fetching prt rewards', err)
     }
-  }, [address])
+  }, [address, tokenAddress])
 
   useEffect(() => {
     fetchRewards()


### PR DESCRIPTION
Adds `tokenAddress` query parameter (currently ignored by endpoint) to support returning PRT values for different tokens.