### PR TITLE
fix: rwa presale end date

### DIFF
--- a/src/app/presales/constants.ts
+++ b/src/app/presales/constants.ts
@@ -19,7 +19,7 @@ export const preSaleTokens: PreSaleToken[] = [
     prtRewards: '10,000 / 100,000',
     targetFundraise: 500,
     launchDate: 'August 19th, 2024',
-    timestampEndDate: 1724068800000,
+    timestampEndDate: 1721404800000,
   },
   {
     status: PreSaleStatus.TOKEN_LAUNCHED,


### PR DESCRIPTION
## **Summary of Changes**

* Fixes wrong end date for presale of RWA

https://gov.indexcoop.com/t/iip-188-launch-the-real-world-asset-index-rwa-presale/4792#presale-details-11

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
