### PR TITLE
fix: quote results when switching chains

### DIFF
--- a/src/lib/hooks/use-best-quote/index.ts
+++ b/src/lib/hooks/use-best-quote/index.ts
@@ -336,6 +336,15 @@ export const useBestQuote = (
     quoteRedemption,
   ])
 
+  useEffect(() => {
+    // Reset quotes
+    setQuote0x(null)
+    setQuoteFlashmint(null)
+    setQuoteIssuance(null)
+    setQuoteRedemption(null)
+    setQuoteResults(defaultResults)
+  }, [chainId])
+
   const isFetchingAnyQuote = useMemo(() => {
     return isFetching0x || isFetchingFlashmint
   }, [isFetching0x, isFetchingFlashmint])

--- a/src/lib/hooks/use-best-quote/utils/quote-results.test.ts
+++ b/src/lib/hooks/use-best-quote/utils/quote-results.test.ts
@@ -1,0 +1,101 @@
+import { BigNumber } from 'ethers'
+
+import {
+  Bitcoin2xFlexibleLeverageIndex,
+  ETH,
+  HighYieldETHIndex,
+  IndexCoopBitcoin2xIndex,
+} from '@/constants/tokens'
+
+import { Quote, QuoteType, ZeroExQuote } from '../types'
+
+import { getQuoteResults } from './quote-results'
+
+describe('getQuoteResults', () => {
+  it('returns redemption quote', async () => {
+    const redemptionQuote = mockQuote
+    redemptionQuote.type = QuoteType.redemption
+    const quoteResults = getQuoteResults(
+      IndexCoopBitcoin2xIndex,
+      Bitcoin2xFlexibleLeverageIndex,
+      IndexCoopBitcoin2xIndex,
+      null,
+      null,
+      null,
+      redemptionQuote,
+    )
+    expect(quoteResults.bestQuote).toEqual(QuoteType.redemption)
+    const results = quoteResults.results
+    expect(results.flashmint?.quote).toBeNull()
+    expect(results.index?.quote).toBeNull()
+    expect(results.issuance?.quote).toBeNull()
+    expect(results.redemption).toEqual({
+      type: QuoteType.redemption,
+      isAvailable: true,
+      quote: redemptionQuote,
+      error: null,
+    })
+  })
+
+  it('returns best quote', async () => {
+    const flashmintQuote = mockQuote
+    flashmintQuote.type = QuoteType.flashmint
+    flashmintQuote.fullCostsInUsd = 9
+    flashmintQuote.outputTokenAmountUsdAfterFees = 10
+    const indexQuote: ZeroExQuote = {
+      ...mockQuote,
+      fullCostsInUsd: 10,
+      outputTokenAmountUsdAfterFees: 1,
+      minOutput: BigNumber.from(0),
+      sources: [{ name: 'LiFi', proportion: '1' }],
+    }
+    const quoteResults = getQuoteResults(
+      HighYieldETHIndex,
+      ETH,
+      HighYieldETHIndex,
+      indexQuote,
+      flashmintQuote,
+      null,
+      null,
+    )
+    expect(quoteResults.bestQuote).toEqual(QuoteType.flashmint)
+    const results = quoteResults.results
+    expect(results.issuance?.quote).toBeNull()
+    expect(results.redemption?.quote).toBeNull()
+    expect(results.flashmint?.quote).toEqual(flashmintQuote)
+    expect(results.index?.quote).toEqual(indexQuote)
+  })
+})
+
+const mockQuote: Quote = {
+  type: QuoteType.flashmint,
+  chainId: 1,
+  contract: '0x0',
+  isMinting: true,
+  inputToken: Bitcoin2xFlexibleLeverageIndex,
+  outputToken: IndexCoopBitcoin2xIndex,
+  gas: BigNumber.from(0),
+  gasPrice: BigNumber.from(0),
+  gasCosts: BigNumber.from(0),
+  gasCostsInUsd: 0,
+  fullCostsInUsd: 0,
+  priceImpact: 0,
+  indexTokenAmount: BigNumber.from(0),
+  inputOutputTokenAmount: BigNumber.from(0),
+  // Return additionally for convenience to avoid
+  // having to determine based on isMinting
+  inputTokenAmount: BigNumber.from(0),
+  inputTokenAmountUsd: 0,
+  outputTokenAmount: BigNumber.from(0),
+  outputTokenAmountUsd: 0,
+  outputTokenAmountUsdAfterFees: 0,
+  inputTokenPrice: 0,
+  outputTokenPrice: 0,
+  slippage: 0,
+  tx: {
+    account: '0x0',
+    to: '0x0',
+    data: '0x',
+    value: BigNumber.from(0),
+  },
+}

--- a/src/lib/hooks/use-best-quote/utils/quote-results.ts
+++ b/src/lib/hooks/use-best-quote/utils/quote-results.ts
@@ -1,0 +1,89 @@
+import { Token } from '@/constants/tokens'
+import {
+  isAvailableForFlashMint,
+  isAvailableForRedemption,
+  isAvailableForSwap,
+} from '@/lib/utils/tokens'
+
+import { Quote, QuoteResults, QuoteType, ZeroExQuote } from '../types'
+
+import { getBestQuote } from './best-quote'
+
+export function getQuoteResults(
+  indexToken: Token,
+  inputToken: Token,
+  outputToken: Token,
+  quote0x: ZeroExQuote | null,
+  quoteFlashMint: Quote | null,
+  quoteIssuance: Quote | null,
+  quoteRedemption: Quote | null,
+): QuoteResults {
+  if (isAvailableForRedemption(inputToken, outputToken)) {
+    return {
+      bestQuote: QuoteType.redemption,
+      results: {
+        flashmint: {
+          type: QuoteType.flashmint,
+          isAvailable: false,
+          quote: null,
+          error: null,
+        },
+        index: {
+          type: QuoteType.index,
+          isAvailable: false,
+          quote: null,
+          error: null,
+        },
+        issuance: {
+          type: QuoteType.issuance,
+          isAvailable: true,
+          quote: null,
+          error: null,
+        },
+        redemption: {
+          type: QuoteType.redemption,
+          isAvailable: true,
+          quote: quoteRedemption,
+          error: null,
+        },
+      },
+    }
+  }
+  const bestQuote = getBestQuote(
+    quote0x?.fullCostsInUsd ?? null,
+    quoteFlashMint?.fullCostsInUsd ?? null,
+    quote0x?.outputTokenAmountUsdAfterFees ?? null,
+    quoteFlashMint?.outputTokenAmountUsdAfterFees ?? null,
+  )
+  const canFlashmintIndexToken = isAvailableForFlashMint(indexToken)
+  const canSwapIndexToken = isAvailableForSwap(indexToken)
+  return {
+    bestQuote,
+    results: {
+      flashmint: {
+        type: QuoteType.flashmint,
+        isAvailable: canFlashmintIndexToken,
+        quote: quoteFlashMint,
+        error: null,
+      },
+      index: {
+        type: QuoteType.index,
+        isAvailable: canSwapIndexToken,
+        quote: quote0x,
+        error: null,
+      },
+      issuance: {
+        type: QuoteType.issuance,
+        isAvailable: false,
+        quote: null,
+        error: null,
+      },
+      redemption: {
+        type: QuoteType.redemption,
+        isAvailable: false,
+        quote: null,
+        error: null,
+      },
+    },
+  }
+}


### PR DESCRIPTION
## **Summary of Changes**

* A user reported to have been seeing wrong quotes (flashmint on Arbitrum which shouldn't exist) after switching from Mainnet to Arbitrum
* Fix by always resetting quotes when switching chains

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
