### PR TITLE
refactor: replace to wei

### DIFF
--- a/src/app/legacy/providers/redeem-provider.tsx
+++ b/src/app/legacy/providers/redeem-provider.tsx
@@ -19,7 +19,7 @@ import { QuoteResult, QuoteType } from '@/lib/hooks/use-best-quote/types'
 import { getEnhancedIssuanceQuote } from '@/lib/hooks/use-best-quote/utils/issuance'
 import { getTokenPrice, useNativeTokenPrice } from '@/lib/hooks/use-token-price'
 import { useWallet } from '@/lib/hooks/use-wallet'
-import { isValidTokenInput, toWei } from '@/lib/utils'
+import { isValidTokenInput, parseUnits } from '@/lib/utils'
 
 export const inputTokenList = [
   GitcoinStakedETHIndex,
@@ -80,7 +80,7 @@ export function RedeemProvider(props: { children: any }) {
     () =>
       inputValue === ''
         ? BigInt(0)
-        : toWei(inputValue, inputToken.decimals).toBigInt(),
+        : parseUnits(inputValue, inputToken.decimals),
     [inputToken, inputValue],
   )
 

--- a/src/app/presales/providers/deposit-provider.tsx
+++ b/src/app/presales/providers/deposit-provider.tsx
@@ -24,7 +24,7 @@ import { getFlashMintQuote } from '@/lib/hooks/use-best-quote/utils/flashmint'
 import { getEnhancedIssuanceQuote } from '@/lib/hooks/use-best-quote/utils/issuance'
 import { getTokenPrice, useNativeTokenPrice } from '@/lib/hooks/use-token-price'
 import { useWallet } from '@/lib/hooks/use-wallet'
-import { isValidTokenInput, toWei } from '@/lib/utils'
+import { isValidTokenInput, parseUnits } from '@/lib/utils'
 
 interface DepositContextProps {
   inputValue: string
@@ -101,7 +101,7 @@ export function DepositProvider(props: {
     () =>
       inputValue === ''
         ? BigInt(0)
-        : toWei(inputValue, inputToken.decimals).toBigInt(),
+        : parseUnits(inputValue, inputToken.decimals),
     [inputToken, inputValue],
   )
 

--- a/src/lib/hooks/use-best-quote/index.ts
+++ b/src/lib/hooks/use-best-quote/index.ts
@@ -1,3 +1,4 @@
+import { BigNumber } from 'ethers'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { usePublicClient } from 'wagmi'
 
@@ -9,7 +10,7 @@ import {
 } from '@/lib/hooks/use-best-quote/utils/issuance'
 import { useNetwork } from '@/lib/hooks/use-network'
 import { useWallet } from '@/lib/hooks/use-wallet'
-import { toWei } from '@/lib/utils'
+import { parseUnits } from '@/lib/utils'
 import {
   getAddressForToken,
   isAvailableForFlashMint,
@@ -75,8 +76,14 @@ export const useBestQuote = (
 
       // Right now we only allow setting the input amount, so no need to check
       // ouput token amount here
-      const inputTokenAmountWei = toWei(inputTokenAmount, inputToken.decimals)
-      if (inputTokenAmountWei.isZero() || inputTokenAmountWei.isNegative()) {
+      const inputTokenAmountWei = parseUnits(
+        inputTokenAmount,
+        inputToken.decimals,
+      )
+      if (
+        inputTokenAmountWei === BigInt(0) ||
+        inputTokenAmountWei < BigInt(0)
+      ) {
         setQuoteResults(defaultResults)
         return
       }
@@ -119,7 +126,9 @@ export const useBestQuote = (
               account: address,
               chainId,
               inputToken,
-              inputTokenAmountWei,
+              inputTokenAmountWei: BigNumber.from(
+                inputTokenAmountWei.toString(),
+              ),
               inputTokenPrice,
               outputToken,
               outputTokenPrice,
@@ -147,7 +156,7 @@ export const useBestQuote = (
               account: address,
               isIssuance: isMinting,
               gasPrice,
-              inputTokenAmount: inputTokenAmountWei.toBigInt(),
+              inputTokenAmount: inputTokenAmountWei,
               inputToken,
               inputTokenPrice,
               outputToken,
@@ -176,7 +185,7 @@ export const useBestQuote = (
               ...request,
               account: address,
               gasPrice: gasPrice,
-              indexTokenAmount: inputTokenAmountWei.toBigInt(),
+              indexTokenAmount: inputTokenAmountWei,
               inputToken,
               inputTokenPrice,
               outputToken,

--- a/src/lib/hooks/use-best-quote/utils/index-quote.ts
+++ b/src/lib/hooks/use-best-quote/utils/index-quote.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber'
 
 import { IndexRpcProvider } from '@/lib/hooks/use-wallet'
-import { formatAmountFromWei, parseUnits, toWei } from '@/lib/utils'
+import { formatAmountFromWei, parseUnits } from '@/lib/utils'
 import { IndexApi } from '@/lib/utils/api/index-api'
 import { getFullCostsInUsd, getGasCostsInUsd } from '@/lib/utils/costs'
 import { GasEstimatooor } from '@/lib/utils/gas-estimatooor'
@@ -104,7 +104,9 @@ export async function getIndexQuote(
       nativeTokenPrice,
     )
 
-    const inputTokenAmountBn = toWei(inputTokenAmount, inputToken.decimals)
+    const inputTokenAmountBn = BigNumber.from(
+      parseUnits(inputTokenAmount, inputToken.decimals).toString(),
+    )
     const outputTokenAmount = BigNumber.from(res.outputAmount)
 
     const inputTokenAmountUsd = parseFloat(inputTokenAmount) * inputTokenPrice

--- a/src/lib/utils/costs.test.ts
+++ b/src/lib/utils/costs.test.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from 'ethers'
 
-import { toWei } from '@/lib/utils'
+import { parseUnits } from '@/lib/utils'
 
 import { getFullCostsInUsd, getGasCostsInUsd } from './costs'
 
@@ -11,17 +11,17 @@ describe('getFullCostsInUsd()', () => {
   })
 
   test('should return input/ouput token amount + gas', async () => {
-    const gasLimit = toWei(0.01)
+    const gasLimit = parseUnits('0.01', 18)
     const gasPrice = BigNumber.from(2)
     const gas = gasPrice.mul(gasLimit)
     const quote = {
       tradeData: [],
-      inputTokenAmount: toWei(1),
+      inputTokenAmount: parseUnits('1', 18),
       setTokenAmount: BigNumber.from(1),
       gas: gasLimit,
     }
     const fullCosts = getFullCostsInUsd(
-      quote.inputTokenAmount.toBigInt(),
+      quote.inputTokenAmount,
       gas.toBigInt(),
       18,
       10,
@@ -33,17 +33,17 @@ describe('getFullCostsInUsd()', () => {
   })
 
   test('should return correct full costs with USDC', async () => {
-    const gasLimit = toWei(0.01)
+    const gasLimit = parseUnits('0.01', 18)
     const gasPrice = BigNumber.from(2)
     const gas = gasPrice.mul(gasLimit)
     const quote = {
       tradeData: [],
-      inputTokenAmount: toWei(1000, 6),
+      inputTokenAmount: parseUnits('1000', 6),
       setTokenAmount: BigNumber.from(1),
       gas: gasLimit,
     }
     const fullCosts = getFullCostsInUsd(
-      quote.inputTokenAmount.toBigInt(),
+      quote.inputTokenAmount,
       gas.toBigInt(),
       6,
       1,
@@ -57,7 +57,7 @@ describe('getFullCostsInUsd()', () => {
 
 describe('getGasCostsInUsd()', () => {
   test('should return gas costs with USDC', async () => {
-    const gasLimit = toWei(0.01)
+    const gasLimit = parseUnits('0.01', 18)
     const gasPrice = BigNumber.from(2)
     const gas = gasPrice.mul(gasLimit)
     const gasCostsInUsd = getGasCostsInUsd(gas.toBigInt(), 2000)

--- a/src/lib/utils/gas-estimatooor.test.ts
+++ b/src/lib/utils/gas-estimatooor.test.ts
@@ -1,8 +1,7 @@
 import { BigNumber, ethers } from 'ethers'
-import { createPublicClient, http } from 'viem'
+import { createPublicClient, http, parseUnits } from 'viem'
 
 import { DefaultGasLimitFlashMintZeroEx } from '@/constants/gas'
-import { toWei } from '@/lib/utils'
 
 import { GasEstimatooor, GasEstimatooorFailedError } from './gas-estimatooor'
 
@@ -34,7 +33,7 @@ describe('GasEstimatooor', () => {
       from: signer.address,
       //   to: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
       gasLimit: BigNumber.from(21_000),
-      value: toWei(1),
+      value: BigNumber.from(parseUnits('1', 18).toString()),
     }
     try {
       await estimatooor.estimate(failingTx)
@@ -52,7 +51,7 @@ describe('GasEstimatooor', () => {
       from: signer.address,
       //   to: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
       gasLimit: BigNumber.from(21_000),
-      value: toWei(1),
+      value: BigNumber.from(parseUnits('1', 18).toString()),
     }
     const gasEstimate = await estimatooor.estimate(failingTx, false)
     expect(gasEstimate.toString()).toEqual(defaultGasEstimate.toString())
@@ -67,7 +66,7 @@ describe('GasEstimatooor', () => {
       from: signer.address,
       to: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
       gasLimit: BigNumber.from(21_000),
-      value: toWei(1),
+      value: BigNumber.from(parseUnits('1', 18).toString()),
     }
     const gasEstimate = await estimatooor.estimate(tx, false)
     expect(gasEstimate.toString()).toEqual('23101')

--- a/src/lib/utils/index.test.ts
+++ b/src/lib/utils/index.test.ts
@@ -1,10 +1,8 @@
-import { BigNumber } from '@ethersproject/bignumber'
-
 import {
   formatAmountFromWei,
   formatDollarAmount,
   isValidTokenInput,
-  toWei,
+  parseUnits,
 } from '.'
 
 describe('formatAmountFromWei', () => {
@@ -86,22 +84,22 @@ describe('isValidTokenInput()', () => {
   })
 })
 
-describe('toWei', () => {
+describe('parseUnits', () => {
   it('should convert string token value to wei', () => {
-    const value = toWei(Number('40.242'))
-    expect(value).toStrictEqual(BigNumber.from('40242000000000000000'))
+    const value = parseUnits('40.242', 18)
+    expect(value).toStrictEqual(BigInt('40242000000000000000'))
   })
   it('should convert number token value to wei', () => {
-    const value = toWei(40.242)
-    expect(value).toStrictEqual(BigNumber.from('40242000000000000000'))
+    const value = parseUnits((40.242).toString(), 18)
+    expect(value).toStrictEqual(BigInt('40242000000000000000'))
   })
   it('should convert USDC to wei', () => {
-    const value = toWei(Number('40.242'), 6)
-    expect(value).toStrictEqual(BigNumber.from('40242000'))
+    const value = parseUnits('40.242', 6)
+    expect(value).toStrictEqual(BigInt('40242000'))
   })
   it('should convert loooong values for USDC to wei', () => {
-    const value = toWei('1265.544702110571614391', 6)
-    expect(value).toStrictEqual(BigNumber.from('1265544702'))
+    const value = parseUnits('1265.544702110571614391', 6)
+    expect(value).toStrictEqual(BigInt('1265544702'))
   })
 })
 

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -3,7 +3,6 @@ import {
   parseUnits as parseUnitsEthers,
 } from '@ethersproject/units'
 import { TokenData } from '@indexcoop/tokenlists'
-import { BigNumber } from 'ethers'
 import { isAddress as isAddressViem, parseUnits as parseUnitsViem } from 'viem'
 
 import { Token } from '@/constants/tokens'
@@ -97,44 +96,6 @@ export function formatWeiAsNumber(
 
 export function parseUnits(value: string, units: number): bigint {
   return parseUnitsViem(value, units)
-}
-
-/**
- * IDEALLY, DO NOT USE ANY OF THE BELOW FUNCTIONS ANY LONGER
- */
-
-/**
- * Converts a number to Wei to another denomination of Eth.
- * Note: will loose precision if fraction part is greater than the decimals.
- * @param valueToConvert
- * @param power default = 18
- * @returns converted number as BigNumber
- */
-export const toWei = (
-  valueToConvert: number | string,
-  power: number = 18,
-): BigNumber => {
-  // parseUnits only accepts strings
-  let value =
-    typeof valueToConvert === 'number'
-      ? valueToConvert.toString()
-      : valueToConvert
-
-  const splits = value.split('.')
-  const integerPart = splits[0]
-  let fractionalPart = splits[1]
-
-  if (!fractionalPart) {
-    return parseUnitsEthers(integerPart, power)
-  }
-
-  if (fractionalPart.length > power) {
-    // Fractional components must not exceed decimals
-    fractionalPart = fractionalPart.substring(0, power)
-  }
-
-  value = integerPart + '.' + fractionalPart
-  return parseUnitsEthers(value, power)
 }
 
 /**


### PR DESCRIPTION
## **Summary of Changes**

* Replaces `toWei` with already existing internal `parseUnits` 

Missing part to close #1350 

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
