### PR TITLE
fix: Empty ERC20 balance call

### DIFF
--- a/src/app/leverage/provider.tsx
+++ b/src/app/leverage/provider.tsx
@@ -43,6 +43,9 @@ import { BaseTokenStats } from './types'
 
 const baseTokens = [ETH, BTC]
 const currencyTokens = [ETH, WETH, WBTC, USDC, USDT]
+const chainTokenAddresses = {
+  [ARBITRUM.chainId]: leverageTokenAddresses,
+}
 
 export enum LeverageType {
   Long2x,
@@ -143,8 +146,7 @@ export function LeverageProvider(props: { children: any }) {
   const [stats, setStats] = useState<BaseTokenStats | null>(null)
   const { balances, forceRefetchBalances } = useBalances(
     address,
-    leverageTokenAddresses,
-    chainId !== ARBITRUM.chainId,
+    chainTokenAddresses[chainId ?? -1],
   )
   const [quoteResult, setQuoteResult] = useState<QuoteResult>({
     type: QuoteType.flashmint,

--- a/src/app/leverage/provider.tsx
+++ b/src/app/leverage/provider.tsx
@@ -144,6 +144,7 @@ export function LeverageProvider(props: { children: any }) {
   const { balances, forceRefetchBalances } = useBalances(
     address,
     leverageTokenAddresses,
+    chainId !== ARBITRUM.chainId,
   )
   const [quoteResult, setQuoteResult] = useState<QuoteResult>({
     type: QuoteType.flashmint,

--- a/src/lib/hooks/use-balance.ts
+++ b/src/lib/hooks/use-balance.ts
@@ -63,12 +63,17 @@ export interface TokenBalance {
   value: bigint
 }
 
-export function useBalances(address?: string, tokens?: string[]) {
+export function useBalances(
+  address?: string,
+  tokens?: string[],
+  disabled?: boolean,
+) {
   const publicClient = usePublicClient()
   const [balances, setBalances] = useState<TokenBalance[]>([])
 
   const fetchBalances = useCallback(async () => {
-    if (!address || !publicClient || !tokens || tokens.length === 0) return
+    if (!address || !publicClient || !tokens || tokens.length === 0 || disabled)
+      return
     const balanceProvider = new BalanceProvider(publicClient)
     const promises = tokens.map((token) => {
       if (token.length === 0) return BigInt(0)
@@ -84,7 +89,7 @@ export function useBalances(address?: string, tokens?: string[]) {
       return { token: token, value: results[index] }
     })
     setBalances(balances)
-  }, [address, tokens, publicClient])
+  }, [address, disabled, tokens, publicClient])
 
   useEffect(() => {
     fetchBalances()

--- a/src/lib/hooks/use-balance.ts
+++ b/src/lib/hooks/use-balance.ts
@@ -63,17 +63,12 @@ export interface TokenBalance {
   value: bigint
 }
 
-export function useBalances(
-  address?: string,
-  tokens?: string[],
-  disabled?: boolean,
-) {
+export function useBalances(address?: string, tokens?: string[]) {
   const publicClient = usePublicClient()
   const [balances, setBalances] = useState<TokenBalance[]>([])
 
   const fetchBalances = useCallback(async () => {
-    if (!address || !publicClient || !tokens || tokens.length === 0 || disabled)
-      return
+    if (!address || !publicClient || !tokens || tokens.length === 0) return
     const balanceProvider = new BalanceProvider(publicClient)
     const promises = tokens.map((token) => {
       if (token.length === 0) return BigInt(0)
@@ -89,7 +84,7 @@ export function useBalances(
       return { token: token, value: results[index] }
     })
     setBalances(balances)
-  }, [address, disabled, tokens, publicClient])
+  }, [address, tokens, publicClient])
 
   useEffect(() => {
     fetchBalances()


### PR DESCRIPTION
Fixes the superfluous `balanceOf` calls. Additional refactoring would be needed to support skipping all balance calls against invalid tokens for a particular chain.