### PR TITLE
fix: Amount parsing

### DIFF
--- a/src/app/leverage/utils/fetch-leverage-token-prices.ts
+++ b/src/app/leverage/utils/fetch-leverage-token-prices.ts
@@ -3,7 +3,7 @@ import { Dispatch, SetStateAction } from 'react'
 import { formatPrice } from '@/app/products/utils/formatters'
 import { ARBITRUM } from '@/constants/chains'
 import { TokenBalance } from '@/lib/hooks/use-balance'
-import { formatAmountFromWei } from '@/lib/utils'
+import { formatWei } from '@/lib/utils'
 import { NavProvider } from '@/lib/utils/api/nav'
 
 import { leverageTokens } from '../constants'
@@ -55,8 +55,7 @@ export async function fetchLeverageTokenPrices(
 
     const enrichedTokens = tokenBalances.map((token, idx) => {
       const usd =
-        parseFloat(formatAmountFromWei(token.balance, token.decimals, 3)) *
-        tokenPrices[idx]
+        parseFloat(formatWei(token.balance, token.decimals)) * tokenPrices[idx]
       return {
         ...token,
         leverageType: getLeverageType(token),

--- a/src/lib/hooks/use-best-quote/utils/flashmint.ts
+++ b/src/lib/hooks/use-best-quote/utils/flashmint.ts
@@ -4,7 +4,7 @@ import { utils } from 'ethers'
 
 import { Token } from '@/constants/tokens'
 import { IndexRpcProvider } from '@/lib/hooks/use-wallet'
-import { formatAmountFromWei } from '@/lib/utils'
+import { formatWei } from '@/lib/utils'
 import { getConfiguredZeroExSwapQuoteProvider } from '@/lib/utils/api/zeroex'
 import { getFullCostsInUsd, getGasCostsInUsd } from '@/lib/utils/costs'
 import { getFlashMintGasDefault } from '@/lib/utils/gas-defaults'
@@ -86,19 +86,11 @@ async function getEnhancedFlashMintQuote(
 
       const inputTokenAmountUsd =
         parseFloat(
-          formatAmountFromWei(
-            inputTokenAmount.toBigInt(),
-            inputToken.decimals,
-            10,
-          ),
+          formatWei(inputTokenAmount.toBigInt(), inputToken.decimals),
         ) * inputTokenPrice
       const outputTokenAmountUsd =
         parseFloat(
-          formatAmountFromWei(
-            outputTokenAmount.toBigInt(),
-            outputToken.decimals,
-            10,
-          ),
+          formatWei(outputTokenAmount.toBigInt(), outputToken.decimals),
         ) * outputTokenPrice
       const priceImpact = getPriceImpact(
         inputTokenAmountUsd,

--- a/src/lib/hooks/use-best-quote/utils/index-quote.ts
+++ b/src/lib/hooks/use-best-quote/utils/index-quote.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber'
 
 import { IndexRpcProvider } from '@/lib/hooks/use-wallet'
-import { formatAmountFromWei, parseUnits } from '@/lib/utils'
+import { formatWei, parseUnits } from '@/lib/utils'
 import { IndexApi } from '@/lib/utils/api/index-api'
 import { getFullCostsInUsd, getGasCostsInUsd } from '@/lib/utils/costs'
 import { GasEstimatooor } from '@/lib/utils/gas-estimatooor'
@@ -112,11 +112,7 @@ export async function getIndexQuote(
     const inputTokenAmountUsd = parseFloat(inputTokenAmount) * inputTokenPrice
     const outputTokenAmountUsd =
       parseFloat(
-        formatAmountFromWei(
-          outputTokenAmount.toBigInt(),
-          outputToken.decimals,
-          10,
-        ),
+        formatWei(outputTokenAmount.toBigInt(), outputToken.decimals),
       ) * outputTokenPrice
     const priceImpact = getPriceImpact(
       inputTokenAmountUsd,


### PR DESCRIPTION
## **Summary of Changes**

Avoids calling `parseFloat` on a number that could contain a comma as anything after it would get truncated (`formatWeiAmount` could return a number with a comma in it). 

<img width="419" alt="image" src="https://github.com/user-attachments/assets/37821d36-f44c-4d37-8712-4861973dd081">

