### PR TITLE
Feature: Default sort by TVL

### DIFF
--- a/src/app/products/components/product-list.tsx
+++ b/src/app/products/components/product-list.tsx
@@ -23,7 +23,7 @@ export function ProductList() {
 
   const {data: products, isFetching} = useQuery({
     initialData: [[], []] as [any[], any[]],
-    queryKey: ['product-list'],
+    queryKey: ['product-list', sortBy, sortDirection],
     queryFn: async () => {
       const analyticsPromises = Promise.all(
         productTokens.map((token) =>

--- a/src/app/products/components/product-list.tsx
+++ b/src/app/products/components/product-list.tsx
@@ -12,8 +12,6 @@ import { fetchAnalytics, fetchApy } from '@/app/products/utils/api'
 import { sortProducts } from '@/app/products/utils/sort'
 import { formatWei } from '@/lib/utils'
 
-const THIRTY_SECONDS_IN_MS = 30 * 1000
-
 export function ProductList() {
   const router = useRouter()
   const pathname = usePathname()
@@ -57,7 +55,6 @@ export function ProductList() {
         sortDirection,
       )
     },
-    refetchInterval: THIRTY_SECONDS_IN_MS,
   })
 
   const handleSortClick = (clickedSortBy: string) => {

--- a/src/app/products/components/product-list.tsx
+++ b/src/app/products/components/product-list.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useQuery } from '@tanstack/react-query'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 
 import { ProductColHeader } from '@/app/products/components/product-col-header'
@@ -10,7 +11,6 @@ import { SortBy, SortDirection } from '@/app/products/types/sort'
 import { fetchAnalytics, fetchApy } from '@/app/products/utils/api'
 import { sortProducts } from '@/app/products/utils/sort'
 import { formatWei } from '@/lib/utils'
-import { useQuery } from '@tanstack/react-query'
 
 const THIRTY_SECONDS_IN_MS = 30 * 1000
 

--- a/src/app/products/components/product-list.tsx
+++ b/src/app/products/components/product-list.tsx
@@ -21,7 +21,7 @@ export function ProductList() {
   const sortBy = searchParams.get('sort')
   const sortDirection = searchParams.get('dir') ?? SortDirection.DESC
 
-  const {data: products, isFetching} = useQuery({
+  const { data: products, isFetching } = useQuery({
     initialData: [[], []] as [any[], any[]],
     queryKey: ['product-list', sortBy, sortDirection],
     queryFn: async () => {
@@ -42,16 +42,20 @@ export function ProductList() {
     select: (data) => {
       const [analyticsResults, apyResults] = data
 
-      return sortProducts(productTokens.map((token, idx) => ({
-        ...token,
-        price: analyticsResults[idx]?.navPrice,
-        delta: analyticsResults[idx]?.change24h,
-        tvl: analyticsResults[idx]?.marketCap,
-        apy:
-          apyResults[idx]?.apy !== undefined && apyResults[idx].apy !== '0'
-            ? Number(formatWei(apyResults[idx].apy))
-            : null,
-      })) as ProductRow[], sortBy ?? 'tvl', sortDirection)
+      return sortProducts(
+        productTokens.map((token, idx) => ({
+          ...token,
+          price: analyticsResults[idx]?.navPrice,
+          delta: analyticsResults[idx]?.change24h,
+          tvl: analyticsResults[idx]?.marketCap,
+          apy:
+            apyResults[idx]?.apy !== undefined && apyResults[idx].apy !== '0'
+              ? Number(formatWei(apyResults[idx].apy))
+              : null,
+        })) as ProductRow[],
+        sortBy ?? 'tvl',
+        sortDirection,
+      )
     },
     refetchInterval: THIRTY_SECONDS_IN_MS,
   })

--- a/src/app/products/components/product-row-item/product-row-item-desktop.tsx
+++ b/src/app/products/components/product-row-item/product-row-item-desktop.tsx
@@ -30,32 +30,54 @@ export function ProductRowItemDesktop({
           'flex !min-w-[410px] max-w-[460px] pl-6',
         )}
       >
-        <div className='mr-2 overflow-hidden rounded-full'>
-          <Image src={image!} alt={`${symbol} logo`} height={30} width={30} />
-        </div>
-        <div className='my-auto'>
-          <span className='text-ic-gray-950 mr-4 font-semibold'>{name}</span>
-          <span className='text-ic-gray-400'>{symbol}</span>
-        </div>
+        {isLoading ? (
+          <LoadingSkeleton className='w-full' />
+        ) : (
+          <>
+            <div className='mr-2 overflow-hidden rounded-full'>
+              <Image
+                src={image!}
+                alt={`${symbol} logo`}
+                height={30}
+                width={30}
+              />
+            </div>
+            <div className='my-auto'>
+              <span className='text-ic-gray-950 mr-4 font-semibold'>
+                {name}
+              </span>
+              <span className='text-ic-gray-400'>{symbol}</span>
+            </div>
+          </>
+        )}
       </div>
       <div className={cellClassName}>
-        <div
-          className={clsx(
-            'border-ic-gray-500 mx-auto w-28 rounded-2xl border px-4 py-1 text-center',
-            {
-              'bg-[#E7F2FF]': type === ProductType.LEVERAGE,
-              'bg-[#F4ECFF]': type === ProductType.INDEX,
-              'bg-[#FEEFF7]': type === ProductType.YIELD,
-            },
-          )}
-        >
-          {type}
-        </div>
+        {isLoading ? (
+          <LoadingSkeleton />
+        ) : (
+          <div
+            className={clsx(
+              'border-ic-gray-500 mx-auto w-28 rounded-2xl border px-4 py-1 text-center',
+              {
+                'bg-[#E7F2FF]': type === ProductType.LEVERAGE,
+                'bg-[#F4ECFF]': type === ProductType.INDEX,
+                'bg-[#FEEFF7]': type === ProductType.YIELD,
+              },
+            )}
+          >
+            {type}
+          </div>
+        )}
       </div>
+
       <div className={cellClassName}>
-        <div className='bg-ic-gray-300 border-ic-gray-500 mx-auto w-28 rounded-2xl border px-4 py-1 text-center'>
-          {theme}
-        </div>
+        {isLoading ? (
+          <LoadingSkeleton />
+        ) : (
+          <div className='bg-ic-gray-300 border-ic-gray-500 mx-auto w-28 rounded-2xl border px-4 py-1 text-center'>
+            {theme}
+          </div>
+        )}
       </div>
       <div className={clsx(cellClassName, '!min-w-[130px] px-2 text-right')}>
         {isLoading ? <LoadingSkeleton /> : formatPrice(price)}


### PR DESCRIPTION
## **Summary of Changes**
Sort Products by TVL 
## **Test Data or Screenshots**
<img width="1307" alt="Screenshot 2024-09-11 at 10 23 24" src="https://github.com/user-attachments/assets/480e777e-b8c4-4d52-b405-34861a2387c3">

This is just a proposal, but demonstrates how useQuery helps out with a lot of things. The pr implementation will result in refetching every 30 seconds, but also if the user refocuses the window, it will automatically rerun so we might as well remove the constant refetch (let's discuss). The result will be cached under the provided key, upon multiple fetches from different places, the cache will be used, and requests with the same key will also be deduplicated. LMK what do you think.

I know we've talked about the SSR ordering way, but it seems like since the ProductRowItem component already has a skeleton loader, so I felt like its fine this way. I've just added 'tvl' into the `select` mapping of useQuery if sortBy is undefined.
