### PR TITLE
Feature: Address safe wallet closes on TX History

### DIFF
--- a/src/app/leverage/utils/get-leverage-type.ts
+++ b/src/app/leverage/utils/get-leverage-type.ts
@@ -11,19 +11,21 @@ import { LeverageType } from '../types'
 
 export const getLeverageAction = ({
   isMint,
+  isBurn,
   isFromUser,
   isToUser,
   isFromContract,
   isToContract,
 }: {
   isMint: boolean
+  isBurn: boolean
   isFromUser: boolean
   isToUser: boolean
   isFromContract: boolean
   isToContract: boolean
 }): 'open' | 'close' | 'transfer' => {
   if (isMint || (isFromContract && isToUser)) return 'open'
-  if (isFromUser && isToContract) return 'close'
+  if (isBurn || (isFromUser && isToContract)) return 'close'
 
   return 'transfer'
 }

--- a/src/lib/hooks/use-token-history.ts
+++ b/src/lib/hooks/use-token-history.ts
@@ -37,6 +37,7 @@ export const useTokenHistory = (...tokens: (string | Address)[]) => {
       return Promise.all(
         transfers.map(async (transfer) => {
           const isMint = transfer.from === zeroAddress
+          const isBurn = transfer.to === zeroAddress
           const isFromUser = transfer.from === user?.toLowerCase()
           const isToUser = transfer.to === user?.toLowerCase()
 
@@ -45,6 +46,7 @@ export const useTokenHistory = (...tokens: (string | Address)[]) => {
 
           const action = getLeverageAction({
             isMint,
+            isBurn,
             isFromContract,
             isToContract,
             isFromUser,


### PR DESCRIPTION
## **Summary of Changes**
With safe wallets there is an issue of the history widget that 'Close'-s are shown as 'Transfer'-s. This is a test branch to see if adding the counterpart of isMint solves this issue. (SPOILER: it does)
## **Test Data or Screenshots**

<img width="1079" alt="Screenshot 2024-09-13 at 15 11 39" src="https://github.com/user-attachments/assets/911ee965-5369-4bca-b1e6-e91ce5b14364">

