### PR TITLE
chore: link legacy page in footer

### DIFF
--- a/src/components/footer/footer-link.tsx
+++ b/src/components/footer/footer-link.tsx
@@ -1,20 +1,22 @@
 'use client'
 
 import Link from 'next/link'
+import { HTMLAttributeAnchorTarget } from 'react'
 
 import { useAnalytics } from '@/lib/hooks/use-analytics'
 
 type Props = {
   children: string
   href: string
+  target?: HTMLAttributeAnchorTarget | undefined
 }
 
-export function FooterLink({ children, href }: Props) {
+export function FooterLink({ children, href, target }: Props) {
   const { logEvent } = useAnalytics()
   return (
     <li>
       <Link
-        target='_blank'
+        target={target ?? '_blank'}
         href={href}
         className='text-ic-gray-600 hover:text-ic-gray-900 dark:hover:text-ic-gray-400 dark:text-ic-gray-200 text-sm leading-6'
         onClick={() => logEvent('Header Link Clicked', { href })}

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -13,7 +13,11 @@ const navigation = {
       name: 'Press Kit',
       href: 'https://index-coop.notion.site/Index-Coop-Brand-Resources-16bfd8ba832046948bf747b4dc88f899',
     },
-    { name: 'Legacy Products', href: 'https://legacyproducts.indexcoop.com' },
+    {
+      name: 'Legacy Products',
+      href: '/legacy',
+      target: '_self',
+    },
     {
       name: 'Liquidity Mining (discontinued)',
       href: 'https://archive.indexcoop.com/liquidity-mining',
@@ -51,7 +55,11 @@ export function Footer() {
               </h3>
               <ul className='mt-6 space-y-4'>
                 {navigation.resources.map((item) => (
-                  <FooterLink key={item.name} href={item.href}>
+                  <FooterLink
+                    key={item.name}
+                    href={item.href}
+                    target={item.target}
+                  >
                     {item.name}
                   </FooterLink>
                 ))}


### PR DESCRIPTION
## **Summary of Changes**

* Links the previously hidden (and now updated) /legacy page to the footer link `Legacy Products` 
* The old `legacyproducts.indexcoop.com` is deprecated and was not working for a while

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
