### PR TITLE
feat: add multi component receive for legacy UI

### DIFF
--- a/src/app/legacy/components/redeem-widget/components/receive.tsx
+++ b/src/app/legacy/components/redeem-widget/components/receive.tsx
@@ -37,7 +37,7 @@ export function Receive(props: ReceiveProps) {
           </span>
         )}
       </div>
-      <div className='flex w-full flex-col gap-1'>
+      <div className='flex w-full flex-col gap-2'>
         {ouputTokens.length > 0 &&
           ouputTokens.map((outputToken, index) => (
             <OutputTokenView

--- a/src/app/legacy/components/redeem-widget/components/receive.tsx
+++ b/src/app/legacy/components/redeem-widget/components/receive.tsx
@@ -22,7 +22,7 @@ export function Receive(props: ReceiveProps) {
     totalOutputAmountUsd,
   } = props
   return (
-    <div className='border-ic-gray-100 flex flex-col justify-between gap-4 rounded-xl border p-4 dark:border-[#3A6060]'>
+    <div className='border-ic-gray-100 flex flex-col gap-4 rounded-xl border p-4 dark:border-[#3A6060]'>
       <div className='flex flex-col'>
         <Caption caption='Receive' />
         {isLoading && <StyledSkeleton width={120} />}
@@ -66,7 +66,7 @@ export const OutputTokenView = ({
   outputAmountUsd,
   symbol,
 }: OutputTokenViewProps) => (
-  <div className='flex w-full flex-row items-center gap-4 text-sm'>
+  <div className='flex w-full flex-row items-center justify-between gap-4 text-sm'>
     <div className='flex flex-row items-center gap-2'>
       <span>{outputAmount}</span>
       <span className='text-ic-gray-400 text-xs'>{`(${outputAmountUsd})`}</span>

--- a/src/app/legacy/components/redeem-widget/components/receive.tsx
+++ b/src/app/legacy/components/redeem-widget/components/receive.tsx
@@ -6,36 +6,44 @@ import { Token } from '@/constants/tokens'
 
 type ReceiveProps = {
   isLoading: boolean
-  outputAmount: string
-  outputAmountUsd?: string
+  outputAmounts: string[]
+  outputAmountsUsd: string[]
   ouputTokens: Token[]
-  showSelectorButtonChevron?: boolean
+  totalOutputAmountUsd: string
   onSelectToken: () => void
 }
 
 export function Receive(props: ReceiveProps) {
-  const { isLoading, outputAmount, outputAmountUsd, ouputTokens } = props
+  const {
+    isLoading,
+    outputAmounts,
+    outputAmountsUsd,
+    ouputTokens,
+    totalOutputAmountUsd,
+  } = props
   return (
-    <div className='border-ic-gray-100 flex flex-row justify-between rounded-xl border p-4 dark:border-[#3A6060]'>
+    <div className='border-ic-gray-100 flex flex-col justify-between gap-4 rounded-xl border p-4 dark:border-[#3A6060]'>
       <div className='flex flex-col'>
         <Caption caption='Receive' />
         {isLoading && <StyledSkeleton width={120} />}
-        {!isLoading && (
+        {!isLoading && ouputTokens.length === 1 && (
           <span className='dark:text-ic-white text-ic-gray-600'>
-            {outputAmount}
+            {outputAmounts[0]}
           </span>
         )}
-        {!isLoading && outputAmountUsd && (
+        {!isLoading && (
           <span className='dark:text-ic-white text-ic-gray-400 text-xs'>
-            {outputAmountUsd}
+            {totalOutputAmountUsd}
           </span>
         )}
       </div>
-      <div className='flex flex-col gap-4'>
+      <div className='flex w-full flex-col gap-1'>
         {ouputTokens.length > 0 &&
-          ouputTokens.map((outputToken) => (
+          ouputTokens.map((outputToken, index) => (
             <OutputTokenView
               image={outputToken.image}
+              outputAmount={outputAmounts[index]}
+              outputAmountUsd={outputAmountsUsd[index]}
               symbol={outputToken.symbol}
               key={outputToken.address}
             />
@@ -47,12 +55,25 @@ export function Receive(props: ReceiveProps) {
 
 type OutputTokenViewProps = {
   image: string
+  outputAmount: string
+  outputAmountUsd: string
   symbol: string
 }
 
-export const OutputTokenView = ({ image, symbol }: OutputTokenViewProps) => (
-  <div className='flex flex-row items-center'>
-    <Image alt={`${symbol} logo`} src={image} width={20} height={20} />
-    <span className='text-ic-black mx-2 text-sm font-medium'> {symbol}</span>
+export const OutputTokenView = ({
+  image,
+  outputAmount,
+  outputAmountUsd,
+  symbol,
+}: OutputTokenViewProps) => (
+  <div className='flex w-full flex-row items-center gap-4 text-sm'>
+    <div className='flex flex-row items-center gap-2'>
+      <span>{outputAmount}</span>
+      <span className='text-ic-gray-400 text-xs'>{`(${outputAmountUsd})`}</span>
+    </div>
+    <div className='flex flex-row'>
+      <Image alt={`${symbol} logo`} src={image} width={20} height={20} />
+      <span className='text-ic-black mx-2 font-medium'> {symbol}</span>
+    </div>
   </div>
 )

--- a/src/app/legacy/components/redeem-widget/components/receive.tsx
+++ b/src/app/legacy/components/redeem-widget/components/receive.tsx
@@ -1,20 +1,20 @@
+import Image from 'next/image'
+
 import { StyledSkeleton } from '@/components/skeleton'
 import { Caption } from '@/components/swap/components/caption'
-import { SelectorButton } from '@/components/swap/components/selector-button'
 import { Token } from '@/constants/tokens'
 
 type ReceiveProps = {
   isLoading: boolean
   outputAmount: string
   outputAmountUsd?: string
-  selectedOutputToken: Token
+  ouputTokens: Token[]
   showSelectorButtonChevron?: boolean
   onSelectToken: () => void
 }
 
 export function Receive(props: ReceiveProps) {
-  const { isLoading, outputAmount, outputAmountUsd, selectedOutputToken } =
-    props
+  const { isLoading, outputAmount, outputAmountUsd, ouputTokens } = props
   return (
     <div className='border-ic-gray-100 flex flex-row justify-between rounded-xl border p-4 dark:border-[#3A6060]'>
       <div className='flex flex-col'>
@@ -31,12 +31,27 @@ export function Receive(props: ReceiveProps) {
           </span>
         )}
       </div>
-      <SelectorButton
-        image={selectedOutputToken.image}
-        symbol={selectedOutputToken.symbol}
-        showChevron={props.showSelectorButtonChevron}
-        onClick={props.onSelectToken}
-      />
+      <div className='flex flex-col gap-4'>
+        {ouputTokens.length > 0 &&
+          ouputTokens.map((outputToken) => (
+            <OutputTokenView
+              image={outputToken.image}
+              symbol={outputToken.symbol}
+            />
+          ))}
+      </div>
     </div>
   )
 }
+
+type OutputTokenViewProps = {
+  image: string
+  symbol: string
+}
+
+export const OutputTokenView = ({ image, symbol }: OutputTokenViewProps) => (
+  <div className='flex flex-row items-center'>
+    <Image alt={`${symbol} logo`} src={image} width={20} height={20} />
+    <span className='text-ic-black mx-2 text-sm font-medium'> {symbol}</span>
+  </div>
+)

--- a/src/app/legacy/components/redeem-widget/components/receive.tsx
+++ b/src/app/legacy/components/redeem-widget/components/receive.tsx
@@ -37,6 +37,7 @@ export function Receive(props: ReceiveProps) {
             <OutputTokenView
               image={outputToken.image}
               symbol={outputToken.symbol}
+              key={outputToken.address}
             />
           ))}
       </div>

--- a/src/app/legacy/components/redeem-widget/components/receive.tsx
+++ b/src/app/legacy/components/redeem-widget/components/receive.tsx
@@ -1,0 +1,42 @@
+import { StyledSkeleton } from '@/components/skeleton'
+import { Caption } from '@/components/swap/components/caption'
+import { SelectorButton } from '@/components/swap/components/selector-button'
+import { Token } from '@/constants/tokens'
+
+type ReceiveProps = {
+  isLoading: boolean
+  outputAmount: string
+  outputAmountUsd?: string
+  selectedOutputToken: Token
+  showSelectorButtonChevron?: boolean
+  onSelectToken: () => void
+}
+
+export function Receive(props: ReceiveProps) {
+  const { isLoading, outputAmount, outputAmountUsd, selectedOutputToken } =
+    props
+  return (
+    <div className='border-ic-gray-100 flex flex-row justify-between rounded-xl border p-4 dark:border-[#3A6060]'>
+      <div className='flex flex-col'>
+        <Caption caption='Receive' />
+        {isLoading && <StyledSkeleton width={120} />}
+        {!isLoading && (
+          <span className='dark:text-ic-white text-ic-gray-600'>
+            {outputAmount}
+          </span>
+        )}
+        {!isLoading && outputAmountUsd && (
+          <span className='dark:text-ic-white text-ic-gray-400 text-xs'>
+            {outputAmountUsd}
+          </span>
+        )}
+      </div>
+      <SelectorButton
+        image={selectedOutputToken.image}
+        symbol={selectedOutputToken.symbol}
+        showChevron={props.showSelectorButtonChevron}
+        onClick={props.onSelectToken}
+      />
+    </div>
+  )
+}

--- a/src/app/legacy/components/redeem-widget/index.tsx
+++ b/src/app/legacy/components/redeem-widget/index.tsx
@@ -4,7 +4,6 @@ import { useDisclosure } from '@chakra-ui/react'
 import { useWeb3Modal } from '@web3modal/wagmi/react'
 import { useCallback, useMemo } from 'react'
 
-import { Receive } from '@/components/receive'
 import { SelectTokenModal } from '@/components/swap/components/select-token-modal'
 import { TradeInputSelector } from '@/components/swap/components/trade-input-selector'
 import { TransactionReviewModal } from '@/components/swap/components/transaction-review'
@@ -24,6 +23,7 @@ import { formatWei } from '@/lib/utils'
 
 import { useRedeem } from '../../providers/redeem-provider'
 
+import { Receive } from './components/receive'
 import { Summary } from './components/summary'
 import { Title } from './components/title'
 import { useFormattedData } from './use-formatted-data'

--- a/src/app/legacy/components/redeem-widget/index.tsx
+++ b/src/app/legacy/components/redeem-widget/index.tsx
@@ -43,7 +43,7 @@ export function RedeemWidget() {
     isFetchingQuote,
     onChangeInputTokenAmount,
     onSelectInputToken,
-    outputToken,
+    outputTokens,
     issuance,
     quoteResult,
     reset,
@@ -84,7 +84,7 @@ export function RedeemWidget() {
     shouldApprove,
     isApproved,
     isApproving,
-    outputToken,
+    outputTokens[0],
     inputValue,
   )
   const { buttonLabel, isDisabled } = useTradeButton(buttonState)
@@ -179,7 +179,7 @@ export function RedeemWidget() {
         onSelectToken={() => {}}
         outputAmount={outputAmount}
         outputAmountUsd={outputAmountUsd}
-        selectedOutputToken={outputToken}
+        ouputTokens={outputTokens}
         showSelectorButtonChevron={false}
       />
       <Summary />

--- a/src/app/legacy/components/redeem-widget/index.tsx
+++ b/src/app/legacy/components/redeem-widget/index.tsx
@@ -53,9 +53,10 @@ export function RedeemWidget() {
     inputAmoutUsd,
     inputTokenBalance,
     inputTokenBalanceFormatted,
+    outputAmounts,
+    outputAmountsUsd,
     outputAmountUsd,
     forceRefetch,
-    outputAmount,
   } = useFormattedData()
 
   const {
@@ -176,11 +177,11 @@ export function RedeemWidget() {
       />
       <Receive
         isLoading={isFetchingQuote}
-        onSelectToken={() => {}}
-        outputAmount={outputAmount}
-        outputAmountUsd={outputAmountUsd}
+        outputAmounts={outputAmounts}
+        outputAmountsUsd={outputAmountsUsd}
         ouputTokens={outputTokens}
-        showSelectorButtonChevron={false}
+        totalOutputAmountUsd={outputAmountUsd}
+        onSelectToken={() => {}}
       />
       <Summary />
       <TradeButton

--- a/src/app/legacy/components/redeem-widget/use-formatted-data.tsx
+++ b/src/app/legacy/components/redeem-widget/use-formatted-data.tsx
@@ -22,6 +22,7 @@ export function useFormattedData() {
   } = useFormattedBalance(inputToken, address)
 
   const quote = useMemo(() => quoteResult?.quote ?? null, [quoteResult])
+  const legacyQuote = useMemo(() => quoteResult?.legacy ?? null, [quoteResult])
 
   const inputAmount = quote?.inputTokenAmount
     ? `${formatAmount(Number(formatWei(quote?.inputTokenAmount.toBigInt(), quote?.inputToken.decimals)))} ${quote?.inputToken.symbol}`
@@ -35,12 +36,26 @@ export function useFormattedData() {
     [inputTokenAmount, balance],
   )
 
-  const outputAmount = quote?.outputTokenAmount
-    ? `${formatAmount(Number(formatWei(quote?.outputTokenAmount.toBigInt(), quote?.outputToken.decimals)))} ${quote?.outputToken.symbol}`
-    : ''
-  const outputAmountUsd = quote?.outputTokenAmountUsd
-    ? `$${formatAmount(quote?.outputTokenAmountUsd)}`
-    : ''
+  let outputAmounts: string[] = []
+  let outputAmountsUsd: string[] = []
+  let outputAmountUsd = ''
+  if (legacyQuote) {
+    const { outputTokens, outputTokenPricesUsd, units } = legacyQuote
+    outputAmounts = outputTokens.map(
+      (outputToken, index) =>
+        `${formatAmount(Number(formatWei(units[index], outputToken.decimals)))}`,
+    )
+    outputAmountsUsd = outputTokenPricesUsd.map(
+      (price) => `$${formatAmount(price)}`,
+    )
+    const outputAmountUsdRaw = outputTokenPricesUsd.reduce(
+      (total, curr) => total + curr,
+      0,
+    )
+    outputAmountUsd = `$${formatAmount(outputAmountUsdRaw)}`
+  }
+
+  const outputAmount = outputAmounts[0] ?? ''
 
   const shouldShowSummaryDetails = useMemo(
     () => quote !== null && inputValue !== '',
@@ -65,6 +80,8 @@ export function useFormattedData() {
     inputTokenBalanceFormatted: balanceFormatted,
     isFetchingQuote,
     outputAmount,
+    outputAmounts,
+    outputAmountsUsd,
     outputAmountUsd,
     shouldShowSummaryDetails,
     forceRefetch,

--- a/src/app/legacy/components/redeem-widget/use-formatted-data.tsx
+++ b/src/app/legacy/components/redeem-widget/use-formatted-data.tsx
@@ -41,9 +41,8 @@ export function useFormattedData() {
   let outputAmountUsd = ''
   if (legacyQuote) {
     const { outputTokens, outputTokenPricesUsd, units } = legacyQuote
-    outputAmounts = outputTokens.map(
-      (outputToken, index) =>
-        `${formatAmount(Number(formatWei(units[index], outputToken.decimals)))}`,
+    outputAmounts = outputTokens.map((outputToken, index) =>
+      formatAmount(Number(formatWei(units[index], outputToken.decimals))),
     )
     outputAmountsUsd = outputTokenPricesUsd.map(
       (price) => `$${formatAmount(price)}`,

--- a/src/app/legacy/providers/redeem-provider.tsx
+++ b/src/app/legacy/providers/redeem-provider.tsx
@@ -1,8 +1,8 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useState,
 } from 'react'
@@ -52,19 +52,20 @@ export const useRedeem = () => useContext(RedeemContext)
 export function RedeemProvider(props: { children: any }) {
   const nativeTokenPrice = useNativeTokenPrice(1)
   const publicClient = usePublicClient()
+  const queryClient = useQueryClient()
   const { address, provider } = useWallet()
 
   const [inputToken, setInputToken] = useState(LegacyTokenList[0])
-  const [outputTokens, setOutputTokens] = useState<Token[]>([])
   const [inputValue, setInputValue] = useState('')
-  const [isFetchingQuote, setFetchingQuote] = useState(false)
-  const [quoteResult, setQuoteResult] = useState<LegacyRedemptionQuoteResult>({
+
+  const queryKey = 'legay-quote-result'
+  const initialData: LegacyRedemptionQuoteResult = {
     type: QuoteType.issuance,
     isAvailable: true,
     quote: null,
     legacy: null,
     error: null,
-  })
+  }
 
   const inputTokenAmount = useMemo(
     () =>
@@ -73,6 +74,46 @@ export function RedeemProvider(props: { children: any }) {
         : parseUnits(inputValue, inputToken.decimals),
     [inputToken, inputValue],
   )
+
+  const { data: quoteResult, isFetching: isFetchingQuote } = useQuery({
+    enabled: Boolean(address),
+    initialData,
+    queryKey: [
+      queryKey,
+      {
+        address,
+        inputToken,
+        inputTokenAmount: inputTokenAmount.toString(),
+        nativeTokenPrice,
+        provider,
+        publicClient,
+      },
+    ],
+    queryFn: async () => {
+      if (!address) return null
+      if (!provider || !publicClient) return null
+      if (inputTokenAmount <= 0) return null
+      const gasPrice = await provider.getGasPrice()
+      const legacyQuote = await getLegacyRedemptionQuote(
+        {
+          account: address,
+          inputTokenAmount,
+          inputToken,
+          gasPrice,
+          nativeTokenPrice,
+          slippage: 0,
+        },
+        publicClient,
+      )
+      return {
+        type: QuoteType.issuance,
+        isAvailable: true,
+        quote: legacyQuote?.quote ?? null,
+        legacy: legacyQuote?.extended ?? null,
+        error: null,
+      }
+    },
+  })
 
   const onChangeInputTokenAmount = useCallback(
     (input: string) => {
@@ -94,53 +135,8 @@ export function RedeemProvider(props: { children: any }) {
 
   const reset = () => {
     setInputValue('')
-    setQuoteResult({
-      type: QuoteType.issuance,
-      isAvailable: true,
-      quote: null,
-      legacy: null,
-      error: null,
-    })
+    queryClient.setQueryData([queryKey], initialData)
   }
-
-  useEffect(() => {
-    const fetchQuote = async () => {
-      if (!address) return
-      if (!provider || !publicClient) return
-      if (inputTokenAmount <= 0) return
-      setFetchingQuote(true)
-      setOutputTokens([])
-      const gasPrice = await provider.getGasPrice()
-      const legacyQuote = await getLegacyRedemptionQuote(
-        {
-          account: address,
-          inputTokenAmount,
-          inputToken,
-          gasPrice,
-          nativeTokenPrice,
-          slippage: 0,
-        },
-        publicClient,
-      )
-      setFetchingQuote(false)
-      setQuoteResult({
-        type: QuoteType.issuance,
-        isAvailable: true,
-        quote: legacyQuote?.quote ?? null,
-        legacy: legacyQuote?.extended ?? null,
-        error: null,
-      })
-      setOutputTokens(legacyQuote?.extended.outputTokens ?? [])
-    }
-    fetchQuote()
-  }, [
-    address,
-    inputToken,
-    inputTokenAmount,
-    nativeTokenPrice,
-    provider,
-    publicClient,
-  ])
 
   return (
     <RedeemContext.Provider
@@ -150,7 +146,7 @@ export function RedeemProvider(props: { children: any }) {
         isDepositing: false,
         isFetchingQuote,
         inputToken,
-        outputTokens,
+        outputTokens: quoteResult?.legacy?.outputTokens ?? [],
         inputTokenAmount,
         issuance: Issuance[inputToken.symbol],
         quoteResult,

--- a/src/app/legacy/providers/redeem-provider.tsx
+++ b/src/app/legacy/providers/redeem-provider.tsx
@@ -12,8 +12,8 @@ import { Issuance, LegacyTokenList } from '@/app/legacy/config'
 import { getOutputTokens } from '@/app/legacy/providers/utils'
 import { LeveragedRethStakingYield, Token } from '@/constants/tokens'
 import { QuoteResult, QuoteType } from '@/lib/hooks/use-best-quote/types'
-import { getEnhancedIssuanceQuote } from '@/lib/hooks/use-best-quote/utils/issuance'
-import { getTokenPrice, useNativeTokenPrice } from '@/lib/hooks/use-token-price'
+import { getLegacyRedemptionQuote } from '@/lib/hooks/use-best-quote/utils/issuance/legacy-quote'
+import { useNativeTokenPrice } from '@/lib/hooks/use-token-price'
 import { useWallet } from '@/lib/hooks/use-wallet'
 import { isValidTokenInput, parseUnits } from '@/lib/utils'
 
@@ -119,19 +119,13 @@ export function RedeemProvider(props: { children: any }) {
       if (!provider || !publicClient) return
       if (inputTokenAmount <= 0) return
       setFetchingQuote(true)
-      const inputTokenPrice = await getTokenPrice(inputToken, 1)
-      const outputTokenPrice = await getTokenPrice(outputTokens[0], 1)
       const gasPrice = await provider.getGasPrice()
-      const quoteIssuance = await getEnhancedIssuanceQuote(
+      const quoteIssuance = await getLegacyRedemptionQuote(
         {
           account: address,
-          isIssuance: false,
-          gasPrice,
           inputTokenAmount,
           inputToken,
-          inputTokenPrice,
-          outputToken: outputTokens[0],
-          outputTokenPrice,
+          gasPrice,
           nativeTokenPrice,
           slippage: 0,
         },

--- a/src/app/legacy/types.ts
+++ b/src/app/legacy/types.ts
@@ -1,0 +1,13 @@
+import { Token } from '@/constants/tokens'
+import { QuoteResult } from '@/lib/hooks/use-best-quote/types'
+
+export interface LegacyQuote {
+  components: string[]
+  outputTokens: Token[]
+  outputTokenPricesUsd: number[]
+  units: bigint[]
+}
+
+export interface LegacyRedemptionQuoteResult extends QuoteResult {
+  legacy: LegacyQuote | null
+}

--- a/src/lib/hooks/use-best-quote/utils/issuance/legacy-quote.ts
+++ b/src/lib/hooks/use-best-quote/utils/issuance/legacy-quote.ts
@@ -1,0 +1,186 @@
+import {
+  getIssuanceModule,
+  IndexDebtIssuanceModuleV2Address_v2,
+} from '@indexcoop/flash-mint-sdk'
+import { getTokenDataByAddress } from '@indexcoop/tokenlists'
+import { BigNumber } from 'ethers'
+import { Address, encodeFunctionData, PublicClient } from 'viem'
+
+import {
+  BedIndex,
+  LeveragedRethStakingYield,
+  RealWorldAssetIndex,
+  RETH,
+  Token,
+} from '@/constants/tokens'
+import { getTokenPrice } from '@/lib/hooks/use-token-price'
+import { formatWei, isSameAddress } from '@/lib/utils'
+import { getFullCostsInUsd, getGasCostsInUsd } from '@/lib/utils/costs'
+import { GasEstimatooor } from '@/lib/utils/gas-estimatooor'
+
+import { Quote, QuoteTransaction, QuoteType } from '../../types'
+
+import { DebtIssuanceModuleV2Abi } from './debt-issuance-module-v2-abi'
+import { DebtIssuanceProvider } from './provider'
+
+interface IssuanceQuoteRequest {
+  account: string
+  inputToken: Token
+  inputTokenAmount: bigint
+  gasPrice: bigint
+  nativeTokenPrice: number
+  slippage: number
+}
+
+export async function getLegacyRedemptionQuote(
+  request: IssuanceQuoteRequest,
+  publicClient: PublicClient,
+): Promise<Quote | null> {
+  const chainId = 1
+  const { account, inputToken, inputTokenAmount, gasPrice, nativeTokenPrice } =
+    request
+
+  let contract = getIssuanceModule(inputToken.symbol, chainId)
+    .address as Address
+  if (
+    BedIndex.symbol === inputToken.symbol ||
+    LeveragedRethStakingYield.symbol === inputToken.symbol ||
+    RealWorldAssetIndex.symbol === inputToken.symbol
+  ) {
+    contract = IndexDebtIssuanceModuleV2Address_v2
+  }
+
+  if (inputTokenAmount <= 0) return null
+
+  try {
+    const debtIssuanceProvider = new DebtIssuanceProvider(
+      contract,
+      publicClient,
+    )
+    const [components, units] =
+      await debtIssuanceProvider.getComponentRedemptionUnits(
+        inputToken.address! as Address,
+        inputTokenAmount,
+      )
+
+    const isIcReth = isSameAddress(
+      inputToken.address!,
+      LeveragedRethStakingYield.address!,
+    )
+    const outputTokens = isIcReth
+      ? [RETH]
+      : components.map((component) => {
+          const outputToken = getTokenDataByAddress(component, chainId)!
+          return {
+            ...outputToken,
+            // all these properties below will be irrelevant for the legacy redemption
+            image: outputToken.logoURI,
+            coingeckoId: '',
+            fees: { streamingFee: '0' },
+            indexTypes: [],
+            isDangerous: false,
+            url: '',
+          }
+        })
+
+    const inputTokenPrice = await getTokenPrice(inputToken, chainId)
+    const outputTokenPricesPromises = outputTokens.map((outputToken) => {
+      return getTokenPrice(outputToken, chainId)
+    })
+    const outputTokenPrices = await Promise.all(outputTokenPricesPromises)
+    console.log(outputTokenPrices)
+    // TODO:
+    const outputTokenAmountUsd = outputTokenPrices.reduce(
+      (total, price, index) => {
+        console.log(
+          total,
+          price,
+          Number(formatWei(units[index], outputTokens[index].decimals)),
+          formatWei(units[index], outputTokens[index].decimals),
+        )
+        return (
+          total +
+          price * Number(formatWei(units[index], outputTokens[index].decimals))
+        )
+      },
+      0,
+    )
+    console.log('USD', outputTokenAmountUsd)
+
+    const callData = encodeFunctionData({
+      abi: DebtIssuanceModuleV2Abi,
+      functionName: 'redeem',
+      args: [
+        inputToken.address! as Address,
+        inputTokenAmount,
+        account as Address,
+      ],
+    })
+
+    const transaction: QuoteTransaction = {
+      account,
+      chainId: 1,
+      from: account,
+      to: contract,
+      data: callData,
+      value: undefined,
+    }
+
+    const defaultGas = 200_000
+    const defaultGasEstimate = BigInt(defaultGas)
+    const gasEstimatooor = new GasEstimatooor(publicClient, defaultGasEstimate)
+    const canFail = false
+    const gasEstimate = await gasEstimatooor.estimate(transaction, canFail)
+    const gasCosts = gasEstimate * gasPrice
+    const gasCostsInUsd = getGasCostsInUsd(gasCosts, nativeTokenPrice)
+    transaction.gasLimit = BigNumber.from(gasEstimate.toString())
+
+    const inputTokenAmountUsd =
+      parseFloat(formatWei(inputTokenAmount, inputToken.decimals)) *
+      inputTokenPrice
+    // TODO:
+    // const outputTokenAmountUsd =
+    //   parseFloat(formatWei(outputTokenAmount, inputToken.decimals)) *
+    //   outputTokenPrice
+    const outputTokenAmountUsdAfterFees = outputTokenAmountUsd - gasCostsInUsd
+
+    const fullCostsInUsd = getFullCostsInUsd(
+      inputTokenAmount,
+      gasEstimate * gasPrice,
+      inputToken.decimals,
+      inputTokenPrice,
+      nativeTokenPrice,
+    )
+
+    const outputTokenAmount = BigInt(0)
+
+    return {
+      type: QuoteType.issuance,
+      chainId: 1,
+      contract,
+      isMinting: false,
+      inputToken,
+      outputToken: inputToken, // TODO:
+      gas: BigNumber.from(gasEstimate.toString()),
+      gasPrice: BigNumber.from(gasPrice.toString()),
+      gasCosts: BigNumber.from(gasCosts.toString()),
+      gasCostsInUsd,
+      fullCostsInUsd,
+      priceImpact: 0,
+      indexTokenAmount: BigNumber.from(inputTokenAmount.toString()),
+      inputOutputTokenAmount: BigNumber.from(outputTokenAmount.toString()),
+      inputTokenAmount: BigNumber.from(inputTokenAmount.toString()),
+      inputTokenAmountUsd,
+      outputTokenAmount: BigNumber.from(outputTokenAmount.toString()),
+      outputTokenAmountUsd,
+      outputTokenAmountUsdAfterFees,
+      inputTokenPrice,
+      outputTokenPrice: 0,
+      slippage: request.slippage,
+      tx: transaction,
+    }
+  } catch (e) {
+    console.warn('Error fetching issuance quote', e)
+    return null
+  }
+}


### PR DESCRIPTION
## **Summary of Changes**

* Adds support for displaying multiple output tokens e.g. BED (legacy tokens that have not been rebalanced)

## **Test Data or Screenshots**

<img width="1512" alt="Bildschirmfoto 2024-10-01 um 15 22 59" src="https://github.com/user-attachments/assets/4e08a0ab-1e2e-421c-90b5-456cc0f3ec14">
<img width="1512" alt="Bildschirmfoto 2024-10-01 um 15 22 48" src="https://github.com/user-attachments/assets/75d9af46-7cf5-4972-bc1b-2eaea77520bb">


###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
