### PR TITLE
FIX: added default queryparam if coming directly to leverage

### DIFF
--- a/src/lib/hooks/use-query-params.ts
+++ b/src/lib/hooks/use-query-params.ts
@@ -80,7 +80,7 @@ export const useQueryParams = <T extends Partial<UseQueryParamsArgs>>(
   const updateQueryParams = useCallback(
     (newParams: Partial<UseQueryParamsArgs>) => {
       const defaultQueryString = `?buy=ETH2X&sell=ETH&network=1`
-      if(typeof window === 'undefined')  return defaultQueryString
+      if (typeof window === 'undefined') return defaultQueryString
       const queryParams = new URLSearchParams(window.location.search)
 
       const { network, inputToken, outputToken } = newParams

--- a/src/lib/hooks/use-query-params.ts
+++ b/src/lib/hooks/use-query-params.ts
@@ -79,6 +79,8 @@ export const useQueryParams = <T extends Partial<UseQueryParamsArgs>>(
 
   const updateQueryParams = useCallback(
     (newParams: Partial<UseQueryParamsArgs>) => {
+      const defaultQueryString = `?buy=ETH2X&sell=ETH&network=1`
+      if(typeof window === 'undefined')  return defaultQueryString
       const queryParams = new URLSearchParams(window.location.search)
 
       const { network, inputToken, outputToken } = newParams


### PR DESCRIPTION
## **Summary of Changes**
Added a default queryParam in case the user is arriving directly at the /leverage page.

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
