### PR TITLE
feat: add ic21 to legacy

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {
-    missingSuspenseWithCSRBailout: false
+    missingSuspenseWithCSRBailout: false,
   },
   async headers() {
     return [
@@ -22,10 +22,14 @@ const nextConfig = {
           },
         ],
       },
-    ];
+    ]
   },
   images: {
     remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'tokens.1inch.io',
+      },
       {
         protocol: 'https',
         hostname: 'assets.coingecko.com',

--- a/src/app/legacy/config.ts
+++ b/src/app/legacy/config.ts
@@ -6,16 +6,19 @@ import {
 import {
   BedIndex,
   GitcoinStakedETHIndex,
+  ic21,
   LeveragedRethStakingYield,
 } from '@/constants/tokens'
 
 export const Issuance = {
   [BedIndex.symbol]: IndexDebtIssuanceModuleV2Address_v2,
   [GitcoinStakedETHIndex.symbol]: IndexDebtIssuanceModuleV2Address,
+  [ic21.symbol]: IndexDebtIssuanceModuleV2Address_v2,
   [LeveragedRethStakingYield.symbol]: IndexDebtIssuanceModuleV2Address_v2,
 }
 
 export const LegacyTokenList = [
+  ic21,
   GitcoinStakedETHIndex,
   LeveragedRethStakingYield,
   BedIndex,

--- a/src/lib/hooks/use-best-quote/utils/issuance/legacy-quote.ts
+++ b/src/lib/hooks/use-best-quote/utils/issuance/legacy-quote.ts
@@ -1,19 +1,10 @@
-import {
-  getIssuanceModule,
-  IndexDebtIssuanceModuleV2Address_v2,
-} from '@indexcoop/flash-mint-sdk'
 import { getTokenByChainAndAddress } from '@indexcoop/tokenlists'
 import { BigNumber } from 'ethers'
 import { Address, encodeFunctionData, PublicClient } from 'viem'
 
+import { Issuance } from '@/app/legacy/config'
 import { LegacyQuote } from '@/app/legacy/types'
-import {
-  BedIndex,
-  LeveragedRethStakingYield,
-  RealWorldAssetIndex,
-  RETH,
-  Token,
-} from '@/constants/tokens'
+import { LeveragedRethStakingYield, RETH, Token } from '@/constants/tokens'
 import { getTokenPrice } from '@/lib/hooks/use-token-price'
 import { formatWei, isSameAddress } from '@/lib/utils'
 import { getFullCostsInUsd, getGasCostsInUsd } from '@/lib/utils/costs'
@@ -43,17 +34,9 @@ export async function getLegacyRedemptionQuote(
 
   if (inputTokenAmount <= 0) return null
 
-  let contract = getIssuanceModule(inputToken.symbol, chainId)
-    .address as Address
-  if (
-    BedIndex.symbol === inputToken.symbol ||
-    LeveragedRethStakingYield.symbol === inputToken.symbol ||
-    RealWorldAssetIndex.symbol === inputToken.symbol
-  ) {
-    contract = IndexDebtIssuanceModuleV2Address_v2
-  }
-
   try {
+    // Get issuance module contract
+    const contract = Issuance[inputToken.symbol] as Address
     const debtIssuanceProvider = new DebtIssuanceProvider(
       contract,
       publicClient,


### PR DESCRIPTION
## **Summary of Changes**

* Adds ic21 to legacy page (to already be able to redeem via issuance contract now)

## **Test Data or Screenshots**

<img width="1512" alt="Bildschirmfoto 2024-10-22 um 09 06 29" src="https://github.com/user-attachments/assets/8f37ea51-5b08-40cf-9d69-81d256b0d984">


###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
