### PR TITLE
FIX: do not update the network queryparam immediately just on subsequent c…

### DIFF
--- a/src/app/leverage/provider.tsx
+++ b/src/app/leverage/provider.tsx
@@ -152,7 +152,6 @@ export function LeverageProvider(props: { children: any }) {
   })
 
   const chainId = useMemo(() => {
-    updateQueryParams({ network: chainIdRaw })
     // To control the defaults better
     return queryNetwork ?? chainIdRaw ?? ARBITRUM.chainId
   }, [chainIdRaw, queryNetwork, updateQueryParams])

--- a/src/app/leverage/provider.tsx
+++ b/src/app/leverage/provider.tsx
@@ -152,9 +152,8 @@ export function LeverageProvider(props: { children: any }) {
   })
 
   const chainId = useMemo(() => {
-    // To control the defaults better
     return queryNetwork ?? chainIdRaw ?? ARBITRUM.chainId
-  }, [chainIdRaw, queryNetwork, updateQueryParams])
+  }, [chainIdRaw, queryNetwork])
 
   const baseTokens = useMemo(() => {
     return getBaseTokens(chainId)

--- a/src/app/leverage/provider.tsx
+++ b/src/app/leverage/provider.tsx
@@ -124,7 +124,7 @@ export function LeverageProvider(props: { children: any }) {
       queryIsMinting,
     },
     updateQueryParams,
-  } = useQueryParams(defaultParams)
+  } = useQueryParams({ ...defaultParams, network: chainIdRaw })
 
   const [baseToken, setBaseToken] = useState<Token>(ETH)
 

--- a/src/components/header/network-select.tsx
+++ b/src/components/header/network-select.tsx
@@ -2,18 +2,22 @@
 
 import { ChevronDownIcon } from '@chakra-ui/icons'
 import { Button } from '@headlessui/react'
+import { watchAccount } from '@wagmi/core'
 import { NetworkUtil } from '@web3modal/common'
 import { AssetUtil, NetworkController } from '@web3modal/core'
 import { useWeb3Modal } from '@web3modal/wagmi/react'
 import Image from 'next/image'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 
 import { useNetwork } from '@/lib/hooks/use-network'
-import { chains } from '@/lib/utils/wagmi'
+import { useQueryParams } from '@/lib/hooks/use-query-params'
+import { chains, config } from '@/lib/utils/wagmi'
 
 export const NetworkSelect = () => {
   const { open } = useWeb3Modal()
   const { chainId } = useNetwork()
+  const { queryParams, updateQueryParams } = useQueryParams()
+  const hasMounted = useRef(false)
 
   const chain = useMemo(() => chains.find((c) => c.id === chainId), [chainId])
 
@@ -26,6 +30,28 @@ export const NetworkSelect = () => {
 
     return AssetUtil.getNetworkImageById(currentNetwork?.imageId) ?? ''
   }, [networks, chainId])
+
+  useEffect(() => {
+    const unwatch = watchAccount(config, {
+      // Do not immediately override the chainId with the wallet one when the user arrives.
+      onChange({ chainId }) {
+        const { queryNetwork } = queryParams
+        if (
+          hasMounted.current === true &&
+          queryNetwork &&
+          queryNetwork !== chainId
+        ) {
+          updateQueryParams({
+            network: chainId,
+          })
+        }
+
+        hasMounted.current = true
+      },
+    })
+
+    return () => unwatch()
+  }, [])
 
   return (
     <Button

--- a/src/components/header/network-select.tsx
+++ b/src/components/header/network-select.tsx
@@ -33,16 +33,17 @@ export const NetworkSelect = () => {
   useEffect(() => {
     const unwatch = watchAccount(config, {
       // Do not immediately override the chainId with the wallet one when the user arrives.
-      onChange({ chainId, isConnecting, isReconnecting }) {
+      onChange(account, prevAccount) {
         const { queryNetwork } = queryParams
         if (
-          queryNetwork &&
-          queryNetwork !== chainId &&
-          !isConnecting &&
-          !isReconnecting
+          (queryNetwork &&
+            queryNetwork !== chainId &&
+            !prevAccount.isReconnecting &&
+            !prevAccount.isConnecting) ||
+          prevAccount.chainId !== account.chainId
         ) {
           updateQueryParams({
-            network: chainId,
+            network: account.chainId,
           })
         }
       },

--- a/src/components/header/network-select.tsx
+++ b/src/components/header/network-select.tsx
@@ -7,7 +7,7 @@ import { NetworkUtil } from '@web3modal/common'
 import { AssetUtil, NetworkController } from '@web3modal/core'
 import { useWeb3Modal } from '@web3modal/wagmi/react'
 import Image from 'next/image'
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo } from 'react'
 
 import { useNetwork } from '@/lib/hooks/use-network'
 import { useQueryParams } from '@/lib/hooks/use-query-params'
@@ -17,7 +17,6 @@ export const NetworkSelect = () => {
   const { open } = useWeb3Modal()
   const { chainId } = useNetwork()
   const { queryParams, updateQueryParams } = useQueryParams()
-  const hasMounted = useRef(false)
 
   const chain = useMemo(() => chains.find((c) => c.id === chainId), [chainId])
 
@@ -34,24 +33,24 @@ export const NetworkSelect = () => {
   useEffect(() => {
     const unwatch = watchAccount(config, {
       // Do not immediately override the chainId with the wallet one when the user arrives.
-      onChange({ chainId }) {
+      onChange({ chainId, isConnecting, isReconnecting }) {
+        console.log(isConnecting, isReconnecting)
         const { queryNetwork } = queryParams
         if (
-          hasMounted.current === true &&
           queryNetwork &&
-          queryNetwork !== chainId
+          queryNetwork !== chainId &&
+          !isConnecting &&
+          !isReconnecting
         ) {
           updateQueryParams({
             network: chainId,
           })
         }
-
-        hasMounted.current = true
       },
     })
 
     return () => unwatch()
-  }, [])
+  }, [queryParams, updateQueryParams])
 
   return (
     <Button

--- a/src/components/header/network-select.tsx
+++ b/src/components/header/network-select.tsx
@@ -34,7 +34,6 @@ export const NetworkSelect = () => {
     const unwatch = watchAccount(config, {
       // Do not immediately override the chainId with the wallet one when the user arrives.
       onChange({ chainId, isConnecting, isReconnecting }) {
-        console.log(isConnecting, isReconnecting)
         const { queryNetwork } = queryParams
         if (
           queryNetwork &&

--- a/src/lib/hooks/use-query-params.ts
+++ b/src/lib/hooks/use-query-params.ts
@@ -32,7 +32,7 @@ export const useQueryParams = <T extends Partial<UseQueryParamsArgs>>(
   const router = useRouter()
 
   const queryParams = useMemo(() => {
-    const network = parseInt(searchParams.get('network') || '0')
+    const network = parseInt(searchParams.get('network') ?? '0')
     const buy = searchParams.get('buy') || ''
     const sell = searchParams.get('sell') || ''
 


### PR DESCRIPTION
## **Summary of Changes**
The network queryparam needs to update when the user switches network, but not immediately upon arriving on the leverage site, since it would cause the queryParams to always take on the user's wallet chainId, instead of prompting them on trading to switch network.

## **Test Data or Screenshots**
The following things should be tested:

`[link]/leverage`
- going here, shoud automatically fill up the `buy`, `sell`, and `network` queryParams, where network should be the user's default network.
`[link]/leverage?buy=ETH2X&sell=ETH&network=42161`
- Opening the link above with a different chainId than what you are connected with
- Opening the link with the same chainId you have connected with
- Opening the link, and trying to do a transaction, after signing, it should prompt to switch on the right network, and changing the network parameter
- Upon switching networks in wallet, or in the app selector, it should override the queryparams if there is a network queryparam set.
`[link]/leverage?buy=ETH2X&sell=ETH&network=`
- opening a link like this, should also fill up the network with the user's network

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
