### PR TITLE
feat: canStake messaging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@chakra-ui/react": "^2.8.2",
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",
+        "@floating-ui/react": "0.26.25",
         "@fontsource/open-sauce-sans": "^5.0.7",
         "@headlessui/react": "2.1.6",
         "@heroicons/react": "^2.1.3",
@@ -4535,29 +4536,32 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
-      "integrity": "sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
+      "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.7"
+        "@floating-ui/utils": "^0.2.8"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.10.tgz",
-      "integrity": "sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.11.tgz",
+      "integrity": "sha512-qkMCxSR24v2vGkhYDo/UzxfJN3D4syqSjyuTFz6C7XcpU1pASPRieNI0Kj5VP3/503mOfYiGY891ugBX1GlABQ==",
+      "license": "MIT",
       "dependencies": {
         "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.7"
+        "@floating-ui/utils": "^0.2.8"
       }
     },
     "node_modules/@floating-ui/react": {
-      "version": "0.26.23",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.23.tgz",
-      "integrity": "sha512-9u3i62fV0CFF3nIegiWiRDwOs7OW/KhSUJDNx2MkQM3LbE5zQOY01sL3nelcVBXvX7Ovvo3A49I8ql+20Wg/Hw==",
+      "version": "0.26.25",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.25.tgz",
+      "integrity": "sha512-hZOmgN0NTOzOuZxI1oIrDu3Gcl8WViIkvPMpB4xdd4QD6xAMtwgwr3VPoiyH/bLtRcS1cDnhxLSD1NsMJmwh/A==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/react-dom": "^2.1.1",
-        "@floating-ui/utils": "^0.2.7",
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
         "tabbable": "^6.0.0"
       },
       "peerDependencies": {
@@ -4566,9 +4570,10 @@
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.1.tgz",
-      "integrity": "sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.0.0"
       },
@@ -4578,9 +4583,10 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
-      "integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA=="
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
+      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
+      "license": "MIT"
     },
     "node_modules/@fontsource/open-sauce-sans": {
       "version": "5.0.7",
@@ -33421,44 +33427,44 @@
       }
     },
     "@floating-ui/core": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
-      "integrity": "sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
+      "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
       "requires": {
-        "@floating-ui/utils": "^0.2.7"
+        "@floating-ui/utils": "^0.2.8"
       }
     },
     "@floating-ui/dom": {
-      "version": "1.6.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.10.tgz",
-      "integrity": "sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.11.tgz",
+      "integrity": "sha512-qkMCxSR24v2vGkhYDo/UzxfJN3D4syqSjyuTFz6C7XcpU1pASPRieNI0Kj5VP3/503mOfYiGY891ugBX1GlABQ==",
       "requires": {
         "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.7"
+        "@floating-ui/utils": "^0.2.8"
       }
     },
     "@floating-ui/react": {
-      "version": "0.26.23",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.23.tgz",
-      "integrity": "sha512-9u3i62fV0CFF3nIegiWiRDwOs7OW/KhSUJDNx2MkQM3LbE5zQOY01sL3nelcVBXvX7Ovvo3A49I8ql+20Wg/Hw==",
+      "version": "0.26.25",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.25.tgz",
+      "integrity": "sha512-hZOmgN0NTOzOuZxI1oIrDu3Gcl8WViIkvPMpB4xdd4QD6xAMtwgwr3VPoiyH/bLtRcS1cDnhxLSD1NsMJmwh/A==",
       "requires": {
-        "@floating-ui/react-dom": "^2.1.1",
-        "@floating-ui/utils": "^0.2.7",
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
         "tabbable": "^6.0.0"
       }
     },
     "@floating-ui/react-dom": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.1.tgz",
-      "integrity": "sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
       "requires": {
         "@floating-ui/dom": "^1.0.0"
       }
     },
     "@floating-ui/utils": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
-      "integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA=="
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
+      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
     },
     "@fontsource/open-sauce-sans": {
       "version": "5.0.7",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
+    "@floating-ui/react": "0.26.25",
     "@fontsource/open-sauce-sans": "^5.0.7",
     "@headlessui/react": "2.1.6",
     "@heroicons/react": "^2.1.3",

--- a/src/app/prt-staking/components/prt-section/prt-widget.tsx
+++ b/src/app/prt-staking/components/prt-section/prt-widget.tsx
@@ -13,6 +13,7 @@ import { usePrtStakingContext } from '@/app/prt-staking/provider'
 import { ProductRevenueToken, WidgetTab } from '@/app/prt-staking/types'
 import { TradeInputSelector } from '@/components/swap/components/trade-input-selector'
 import { useFormattedBalance } from '@/components/swap/hooks/use-swap/use-formatted-balance'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/tooltip'
 import { TradeButton } from '@/components/trade-button'
 import { useApproval } from '@/lib/hooks/use-approval'
 import { formatTokenDataToToken, formatWeiAsNumber } from '@/lib/utils'
@@ -95,11 +96,13 @@ export function PrtWidget({ token, onClose }: Props) {
   }, [currentTab])
 
   const buttonLabel = useMemo(() => {
-    if (currentTab === WidgetTab.STAKE) return 'Stake'
+    if (currentTab === WidgetTab.STAKE) {
+      return canStake ? 'Stake' : 'Distribution in process'
+    }
     if (currentTab === WidgetTab.UNSTAKE) return 'Unstake'
     if (currentTab === WidgetTab.CLAIM) return 'Claim Rewards'
     return ''
-  }, [currentTab])
+  }, [canStake, currentTab])
 
   const balance = useMemo(() => {
     if (currentTab === WidgetTab.STAKE) {
@@ -198,12 +201,22 @@ export function PrtWidget({ token, onClose }: Props) {
         onClickBalance={onClickBalance}
         onSelectToken={() => {}}
       />
-      <TradeButton
-        label={buttonLabel}
-        isDisabled={isTradeButtonDisabled}
-        isLoading={isSubmitting || isApproving}
-        onClick={onClickTradeButton}
-      />
+      <Tooltip>
+        <TooltipTrigger className='w-full'>
+          <TradeButton
+            label={buttonLabel}
+            isDisabled={isTradeButtonDisabled}
+            isLoading={isSubmitting || isApproving}
+            onClick={onClickTradeButton}
+          />
+        </TooltipTrigger>
+        {!canStake && (
+          <TooltipContent>
+            PRT Rewards distribution is in progress. Staking is temporarily
+            unavailable during this time. Please try again later.
+          </TooltipContent>
+        )}
+      </Tooltip>
       <SafeSignButton />
     </div>
   )

--- a/src/app/prt-staking/components/prt-section/prt-widget.tsx
+++ b/src/app/prt-staking/components/prt-section/prt-widget.tsx
@@ -13,7 +13,6 @@ import { usePrtStakingContext } from '@/app/prt-staking/provider'
 import { ProductRevenueToken, WidgetTab } from '@/app/prt-staking/types'
 import { TradeInputSelector } from '@/components/swap/components/trade-input-selector'
 import { useFormattedBalance } from '@/components/swap/hooks/use-swap/use-formatted-balance'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/tooltip'
 import { TradeButton } from '@/components/trade-button'
 import { useApproval } from '@/lib/hooks/use-approval'
 import { formatTokenDataToToken, formatWeiAsNumber } from '@/lib/utils'
@@ -201,22 +200,17 @@ export function PrtWidget({ token, onClose }: Props) {
         onClickBalance={onClickBalance}
         onSelectToken={() => {}}
       />
-      <Tooltip>
-        <TooltipTrigger className='w-full'>
-          <TradeButton
-            label={buttonLabel}
-            isDisabled={isTradeButtonDisabled}
-            isLoading={isSubmitting || isApproving}
-            onClick={onClickTradeButton}
-          />
-        </TooltipTrigger>
-        {!canStake && (
-          <TooltipContent>
-            PRT Rewards distribution is in progress. Staking is temporarily
-            unavailable during this time. Please try again later.
-          </TooltipContent>
-        )}
-      </Tooltip>
+      <TradeButton
+        label={buttonLabel}
+        isDisabled={isTradeButtonDisabled}
+        isLoading={isSubmitting || isApproving}
+        onClick={onClickTradeButton}
+        tooltip={
+          !canStake
+            ? 'PRT Rewards distribution is in progress. Staking is temporarily unavailable during this time. Please try again later.'
+            : null
+        }
+      />
       <SafeSignButton />
     </div>
   )

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -156,7 +156,7 @@ export const TooltipContent = forwardRef<
   return (
     <FloatingPortal>
       <div
-        className='text-ic-white z-[2000] box-border rounded-md bg-gray-800 px-2 py-1 text-xs'
+        className='text-ic-white z-[2000] box-border max-w-sm rounded-md bg-gray-800 px-2 py-1 text-center text-xs'
         ref={ref}
         style={{
           ...context.floatingStyles,

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -1,0 +1,169 @@
+import {
+  autoUpdate,
+  flip,
+  FloatingPortal,
+  offset,
+  shift,
+  useDismiss,
+  useFloating,
+  useFocus,
+  useHover,
+  useInteractions,
+  useMergeRefs,
+  useRole,
+} from '@floating-ui/react'
+import {
+  cloneElement,
+  createContext,
+  forwardRef,
+  isValidElement,
+  useContext,
+  useMemo,
+  useState,
+} from 'react'
+
+import type { Placement } from '@floating-ui/react'
+
+interface TooltipOptions {
+  initialOpen?: boolean
+  placement?: Placement
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}
+
+export function useTooltip({
+  initialOpen = false,
+  placement = 'top',
+  open: controlledOpen,
+  onOpenChange: setControlledOpen,
+}: TooltipOptions = {}) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(initialOpen)
+
+  const open = controlledOpen ?? uncontrolledOpen
+  const setOpen = setControlledOpen ?? setUncontrolledOpen
+
+  const data = useFloating({
+    placement,
+    open,
+    onOpenChange: setOpen,
+    whileElementsMounted: autoUpdate,
+    middleware: [
+      offset(5),
+      flip({
+        crossAxis: placement.includes('-'),
+        fallbackAxisSideDirection: 'start',
+        padding: 5,
+      }),
+      shift({ padding: 5 }),
+    ],
+  })
+
+  const context = data.context
+
+  const hover = useHover(context, {
+    move: false,
+    enabled: controlledOpen == null,
+  })
+  const focus = useFocus(context, {
+    enabled: controlledOpen == null,
+  })
+  const dismiss = useDismiss(context)
+  const role = useRole(context, { role: 'tooltip' })
+
+  const interactions = useInteractions([hover, focus, dismiss, role])
+
+  return useMemo(
+    () => ({
+      open,
+      setOpen,
+      ...interactions,
+      ...data,
+    }),
+    [open, setOpen, interactions, data],
+  )
+}
+
+type ContextType = ReturnType<typeof useTooltip> | null
+
+const TooltipContext = createContext<ContextType>(null)
+
+export const useTooltipContext = () => {
+  const context = useContext(TooltipContext)
+
+  if (context == null) {
+    throw new Error('Tooltip components must be wrapped in <Tooltip />')
+  }
+
+  return context
+}
+
+export function Tooltip({
+  children,
+  ...options
+}: { children: React.ReactNode } & TooltipOptions) {
+  // This can accept any props as options, e.g. `placement`,
+  // or other positioning options.
+  const tooltip = useTooltip(options)
+  return (
+    <TooltipContext.Provider value={tooltip}>
+      {children}
+    </TooltipContext.Provider>
+  )
+}
+
+export const TooltipTrigger = forwardRef<
+  HTMLElement,
+  React.HTMLProps<HTMLElement> & { asChild?: boolean }
+>(function TooltipTrigger({ children, asChild = false, ...props }, propRef) {
+  const context = useTooltipContext()
+  const childrenRef = (children as any).ref
+  const ref = useMergeRefs([context.refs.setReference, propRef, childrenRef])
+
+  // `asChild` allows the user to pass any element as the anchor
+  if (asChild && isValidElement(children)) {
+    return cloneElement(
+      children,
+      context.getReferenceProps({
+        ref,
+        ...props,
+        ...children.props,
+        'data-state': context.open ? 'open' : 'closed',
+      }),
+    )
+  }
+
+  return (
+    <button
+      ref={ref}
+      // The user can style the trigger based on the state
+      data-state={context.open ? 'open' : 'closed'}
+      {...context.getReferenceProps(props)}
+    >
+      {children}
+    </button>
+  )
+})
+
+export const TooltipContent = forwardRef<
+  HTMLDivElement,
+  React.HTMLProps<HTMLDivElement>
+>(function TooltipContent({ style, ...props }, propRef) {
+  const context = useTooltipContext()
+  const ref = useMergeRefs([context.refs.setFloating, propRef])
+
+  if (!context.open) return null
+
+  return (
+    <FloatingPortal>
+      <div
+        className='text-ic-white z-[2000] box-border rounded-md bg-gray-800 px-2 py-1 text-xs'
+        ref={ref}
+        style={{
+          ...context.floatingStyles,
+          ...style,
+        }}
+        {...context.getFloatingProps(props)}
+      />
+    </FloatingPortal>
+  )
+})

--- a/src/components/trade-button/index.tsx
+++ b/src/components/trade-button/index.tsx
@@ -9,7 +9,7 @@ interface TradeButtonProps {
   isDisabled: boolean
   isLoading: boolean
   onClick: () => void
-  tooltip: string | null
+  tooltip?: string | null
 }
 
 export const TradeButton = ({

--- a/src/components/trade-button/index.tsx
+++ b/src/components/trade-button/index.tsx
@@ -1,5 +1,7 @@
 import clsx from 'clsx'
 
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/tooltip'
+
 import { Spinner } from './spinner'
 
 interface TradeButtonProps {
@@ -7,6 +9,7 @@ interface TradeButtonProps {
   isDisabled: boolean
   isLoading: boolean
   onClick: () => void
+  tooltip: string | null
 }
 
 export const TradeButton = ({
@@ -14,19 +17,28 @@ export const TradeButton = ({
   isDisabled,
   isLoading,
   onClick,
+  tooltip,
 }: TradeButtonProps) => {
   const disabled = isLoading || isDisabled
+
   return (
-    <button
-      className={clsx(
-        'text-ic-white h-14 w-full rounded-[10px] font-bold',
-        disabled ? 'shadow-none' : 'shadow-[0.5px_1px_2px_0_rgba(0,0,0,0.3)]',
-        disabled ? 'bg-ic-gray-500' : 'bg-ic-blue-600',
-      )}
-      disabled={disabled}
-      onClick={onClick}
-    >
-      {isLoading ? <Spinner /> : label}
-    </button>
+    <Tooltip>
+      <TooltipTrigger className='w-full'>
+        <button
+          className={clsx(
+            'text-ic-white h-14 w-full rounded-[10px] font-bold',
+            disabled
+              ? 'shadow-none'
+              : 'shadow-[0.5px_1px_2px_0_rgba(0,0,0,0.3)]',
+            disabled ? 'bg-ic-gray-500' : 'bg-ic-blue-600',
+          )}
+          disabled={disabled}
+          onClick={onClick}
+        >
+          {isLoading ? <Spinner /> : label}
+        </button>
+      </TooltipTrigger>
+      {tooltip !== null && <TooltipContent>{tooltip}</TooltipContent>}
+    </Tooltip>
   )
 }

--- a/src/components/trade-button/index.tsx
+++ b/src/components/trade-button/index.tsx
@@ -38,7 +38,7 @@ export const TradeButton = ({
           {isLoading ? <Spinner /> : label}
         </button>
       </TooltipTrigger>
-      {tooltip !== null && <TooltipContent>{tooltip}</TooltipContent>}
+      {tooltip && <TooltipContent>{tooltip}</TooltipContent>}
     </Tooltip>
   )
 }


### PR DESCRIPTION
Adds a new `Tooltip` component to eventually support pulling out Chakra and updates the label/tooltip when `canStake` is set to `false`.

<img width="604" alt="image" src="https://github.com/user-attachments/assets/5c6fc96c-8843-463d-a649-621f24eb9133">
