### PR TITLE
fix: Mava loading on /leverage

### DIFF
--- a/src/components/external/mava-script.tsx
+++ b/src/components/external/mava-script.tsx
@@ -1,14 +1,15 @@
+import Script from 'next/script'
+
 export const MavaScript = () => {
   if (process.env.NODE_ENV === 'development') {
     return null
   }
 
   return (
-    <script
-      defer
+    <Script
+      id='MavaWebChat'
       src='https://widget.mava.app'
       widget-version='v2'
-      id='MavaWebChat'
       enable-sdk='false'
       data-token='3b991dd71883754f5d277d35cee1c9acf97229923e76ff349478ac8419142ccb'
     />

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import {
   autoUpdate,
   flip,

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   autoUpdate,
   flip,

--- a/src/components/trade-button/index.tsx
+++ b/src/components/trade-button/index.tsx
@@ -23,20 +23,16 @@ export const TradeButton = ({
 
   return (
     <Tooltip>
-      <TooltipTrigger className='w-full'>
-        <button
-          className={clsx(
-            'text-ic-white h-14 w-full rounded-[10px] font-bold',
-            disabled
-              ? 'shadow-none'
-              : 'shadow-[0.5px_1px_2px_0_rgba(0,0,0,0.3)]',
-            disabled ? 'bg-ic-gray-500' : 'bg-ic-blue-600',
-          )}
-          disabled={disabled}
-          onClick={onClick}
-        >
-          {isLoading ? <Spinner /> : label}
-        </button>
+      <TooltipTrigger
+        className={clsx(
+          'text-ic-white h-14 w-full rounded-[10px] font-bold',
+          disabled ? 'shadow-none' : 'shadow-[0.5px_1px_2px_0_rgba(0,0,0,0.3)]',
+          disabled ? 'bg-ic-gray-500' : 'bg-ic-blue-600',
+        )}
+        disabled={disabled}
+        onClick={onClick}
+      >
+        {isLoading ? <Spinner /> : label}
       </TooltipTrigger>
       {tooltip && <TooltipContent>{tooltip}</TooltipContent>}
     </Tooltip>


### PR DESCRIPTION
## **Summary of Changes**

The Mava widget isn't loading properly on the first load of the `/leverage` page, but would if you navigate to it from another page first - fixed by moving to `next/script`.

Also saw a nextjs hydration error related to the tooltip trigger that was added (button was a descendant of button) - updated to remove the inner button.

## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
