### PR TITLE
fix: Chain switch

### DIFF
--- a/src/app/leverage/provider.tsx
+++ b/src/app/leverage/provider.tsx
@@ -112,7 +112,7 @@ const defaultParams = {
 
 export function LeverageProvider(props: { children: any }) {
   const publicClient = usePublicClient()
-  const { chainId: chainIdRaw } = useNetwork()
+  const { chainId: chainIdRaw, switchChain } = useNetwork()
   const nativeTokenPrice = useNativeTokenPrice(chainIdRaw)
   const { address, provider, rpcUrl } = useWallet()
   const {
@@ -152,8 +152,15 @@ export function LeverageProvider(props: { children: any }) {
   })
 
   const chainId = useMemo(() => {
-    return queryNetwork ?? chainIdRaw ?? ARBITRUM.chainId
-  }, [chainIdRaw, queryNetwork])
+    return chainIdRaw ?? ARBITRUM.chainId
+  }, [chainIdRaw])
+
+  useEffect(() => {
+    // queryNetwork is only set on the initial load
+    if (queryNetwork) {
+      switchChain({ chainId: queryNetwork })
+    }
+  }, [queryNetwork, switchChain])
 
   const baseTokens = useMemo(() => {
     return getBaseTokens(chainId)

--- a/src/lib/hooks/use-network.ts
+++ b/src/lib/hooks/use-network.ts
@@ -1,5 +1,5 @@
 import { arbitrum, base, mainnet } from 'viem/chains'
-import { useAccount } from 'wagmi'
+import { useAccount, useSwitchChain } from 'wagmi'
 
 import { chains } from '@/lib/utils/wagmi'
 
@@ -13,12 +13,13 @@ export function useMainnetOnly() {
 
 export const useNetwork = () => {
   const { chain } = useAccount()
+  const { switchChain } = useSwitchChain()
   const chainId = chain?.id
   const isMainnet = chainId === 1
   const isSupportedNetwork =
     chainId === undefined ? true : chains.some((chain) => chain.id === chainId)
   const name = getNetworkName(chainId)
-  return { chainId, isMainnet, isSupportedNetwork, name }
+  return { chainId, isMainnet, isSupportedNetwork, name, switchChain }
 }
 
 export function useSupportedNetworks(chainIds: number[]) {


### PR DESCRIPTION
## **Summary of Changes**
Updates the logic to call `switchChain` on load if `queryNetwork` is set and ensures the centrally set `chainId` is what gets used throughout the provider.

## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
