### PR TITLE
fix: output amount for small numbers

### DIFF
--- a/src/app/earn/use-formatted-data.tsx
+++ b/src/app/earn/use-formatted-data.tsx
@@ -67,9 +67,13 @@ export function useFormattedLeverageData(
 
   const ouputAmount = useMemo(() => {
     if (inputValue === '') return ''
-    return quote?.outputTokenAmount
-      ? `${formatAmount(Number(formatWei(quote?.outputTokenAmount, quote?.outputToken.decimals)))} ${quote?.outputToken.symbol}`
-      : ''
+    if (!quote?.outputTokenAmount) return ''
+    const amount = Number(
+      formatWei(quote?.outputTokenAmount, quote?.outputToken.decimals),
+    )
+    const digits =
+      amount < 0.01 ? Math.min(6, Math.ceil(-Math.log10(amount)) + 1) : 2
+    return `${formatAmount(amount, digits)} ${quote?.outputToken.symbol}`
   }, [inputValue, quote])
   const outputAmountUsd = quote?.outputTokenAmountUsd
     ? `$${formatAmount(quote?.outputTokenAmountUsd)}`

--- a/src/app/leverage/use-formatted-data.tsx
+++ b/src/app/leverage/use-formatted-data.tsx
@@ -67,9 +67,13 @@ export function useFormattedLeverageData(
 
   const ouputAmount = useMemo(() => {
     if (inputValue === '') return ''
-    return quote?.outputTokenAmount
-      ? `${formatAmount(Number(formatWei(quote?.outputTokenAmount, quote?.outputToken.decimals)))} ${quote?.outputToken.symbol}`
-      : ''
+    if (!quote?.outputTokenAmount) return ''
+    const amount = Number(
+      formatWei(quote?.outputTokenAmount, quote?.outputToken.decimals),
+    )
+    const digits =
+      amount < 0.01 ? Math.min(6, Math.ceil(-Math.log10(amount)) + 1) : 2
+    return `${formatAmount(amount, digits)} ${quote?.outputToken.symbol}`
   }, [inputValue, quote])
   const outputAmountUsd = quote?.outputTokenAmountUsd
     ? `$${formatAmount(quote?.outputTokenAmountUsd)}`


### PR DESCRIPTION
## **Summary of Changes**

* Fixes displaying small numbers for quote output amounts 

## **Test Data or Screenshots**

<img width="200" alt="Bildschirmfoto 2024-11-28 um 09 46 02" src="https://github.com/user-attachments/assets/3aebf039-16ed-4c8e-8109-09c9af1ceabd">
<img width="200" alt="Bildschirmfoto 2024-11-28 um 09 46 34" src="https://github.com/user-attachments/assets/cd372671-a1c6-423b-8f1c-1545178f0b28">
<img width="200" alt="Bildschirmfoto 2024-11-28 um 09 46 49" src="https://github.com/user-attachments/assets/faa02753-1184-44cc-ab11-94057a6443a6">


###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
