### PR TITLE
FIX: add 1s delay for the network message to appear

### DIFF
--- a/src/components/header/network-select.tsx
+++ b/src/components/header/network-select.tsx
@@ -93,7 +93,7 @@ export const NetworkSelect = () => {
             static
             anchor='bottom'
             initial={{ opacity: 0, scale: 0.95 }}
-            animate={{ opacity: 1, scale: 1, animationDelay: '0.5s' }}
+            animate={{ opacity: 1, scale: 1, transition: { delay: 1 } }}
             className='dark:bg-ic-black dark:border-ic-gray-800 z-50 mt-8 w-80 !overflow-visible rounded-md border border-gray-300 bg-white p-4 shadow-md dark:text-white'
             exit={{ opacity: 0, scale: 0.95 }}
           >


### PR DESCRIPTION
## **Summary of Changes**
Add a small delay, to deal with a flicker, while switching networks without confirmation.
## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
