### PR TITLE
feat: add leverage submenus

### DIFF
--- a/src/app/earn/components/faq-section/index.tsx
+++ b/src/app/earn/components/faq-section/index.tsx
@@ -104,7 +104,7 @@ export function FaqSection() {
           </li>
         </ul>
       </FaqItem>
-      <FaqItem question='How does each product determine which protocols are included?'>
+      <FaqItem question='Are Index Coop yield products rebasing tokens or repricing tokens?'>
         <p>
           All Index Coop yield tokens are repricing tokens, meaning they adjust
           in price to reflect changes in value or yield without altering the

--- a/src/app/earn/components/stat-metric.tsx
+++ b/src/app/earn/components/stat-metric.tsx
@@ -9,11 +9,11 @@ type Props = {
 
 export function StatMetric({ className, isLoading, label, value }: Props) {
   return (
-    <div className={cn('flex flex-col gap-1', className)}>
+    <div className={cn('flex-col gap-1', className)}>
       <div className='text-ic-gray-500 text-xs'>{label}</div>
       <div
         className={cn(
-          'text-ic-gray-700 h-6 text-sm font-semibold',
+          'text-ic-gray-700 text-sm font-semibold',
           isLoading && 'bg-ic-gray-200 animate-pulse rounded-md text-opacity-0',
         )}
       >

--- a/src/app/leverage/components/leverage-widget/components/buy-sell-selector.tsx
+++ b/src/app/leverage/components/leverage-widget/components/buy-sell-selector.tsx
@@ -1,0 +1,25 @@
+import { BuySellSelectorButton } from '@/components/selectors/buy-sell-selector-button'
+
+type BuySellSelectorProps = {
+  isMinting: boolean
+  onClick: () => void
+}
+
+export function BuySellSelector({ isMinting, onClick }: BuySellSelectorProps) {
+  return (
+    <div className='bg-ic-gray-50 dark:bg-ic-blue-950 flex flex-row rounded-md'>
+      <BuySellSelectorButton
+        isSelected={isMinting}
+        label='Open'
+        roundedLeft={true}
+        onClick={onClick}
+      />
+      <BuySellSelectorButton
+        isSelected={!isMinting}
+        label='Close'
+        roundedLeft={false}
+        onClick={onClick}
+      />
+    </div>
+  )
+}

--- a/src/app/leverage/components/leverage-widget/index.tsx
+++ b/src/app/leverage/components/leverage-widget/index.tsx
@@ -6,7 +6,6 @@ import { useCallback } from 'react'
 import { supportedNetworks } from '@/app/leverage/constants'
 import { useLeverageToken } from '@/app/leverage/provider'
 import { Receive } from '@/components/receive'
-import { BuySellSelector } from '@/components/selectors/buy-sell-selector'
 import { SmartTradeButton } from '@/components/smart-trade-button'
 import { SelectTokenModal } from '@/components/swap/components/select-token-modal'
 import { TradeInputSelector } from '@/components/swap/components/trade-input-selector'
@@ -20,7 +19,7 @@ import { formatWei } from '@/lib/utils'
 
 import { useFormattedLeverageData } from '../../use-formatted-data'
 
-import { BaseTokenSelector } from './components/base-token-selector'
+import { BuySellSelector } from './components/buy-sell-selector'
 import { Fees } from './components/fees'
 import { LeverageSelector } from './components/leverage-selector'
 import { Summary } from './components/summary'
@@ -38,7 +37,6 @@ export function LeverageWidget(props: LeverageWidgetProps) {
   const { queryParams } = useQueryParams()
   const { address } = useWallet()
   const {
-    baseToken,
     inputToken,
     inputTokenAmount,
     inputTokens,
@@ -93,13 +91,9 @@ export function LeverageWidget(props: LeverageWidgetProps) {
 
   return (
     <div
-      className='leverage-widget flex flex-col gap-3 rounded-3xl p-6'
+      className='leverage-widget flex flex-col gap-3 rounded-md p-6'
       id='close-position-scroll'
     >
-      <BaseTokenSelector
-        baseToken={baseToken}
-        onClick={props.onClickBaseTokenSelector}
-      />
       <BuySellSelector isMinting={isMinting} onClick={toggleIsMinting} />
       <LeverageSelector
         selectedTye={leverageType}

--- a/src/app/leverage/components/leverage-widget/index.tsx
+++ b/src/app/leverage/components/leverage-widget/index.tsx
@@ -28,11 +28,7 @@ import './styles.css'
 
 const hiddenLeverageWarnings = [WarningType.flashbots]
 
-type LeverageWidgetProps = {
-  onClickBaseTokenSelector: () => void
-}
-
-export function LeverageWidget(props: LeverageWidgetProps) {
+export function LeverageWidget() {
   const isSupportedNetwork = useSupportedNetworks(supportedNetworks)
   const { queryParams } = useQueryParams()
   const { address } = useWallet()

--- a/src/app/leverage/components/leverage-widget/styles.css
+++ b/src/app/leverage/components/leverage-widget/styles.css
@@ -11,8 +11,4 @@
       rgba(212, 0, 216, 0.15) 183.55%
     ),
     linear-gradient(195deg, #143438 -23.15%, #052629 227.79%);
-  border: 1px solid #006a71;
-  box-shadow:
-    0.5px 1px 2px 0px rgba(44, 51, 51, 0.25),
-    2px 2px 1px 0px rgba(5, 172, 175, 0.49) inset;
 }

--- a/src/app/leverage/components/stats/index.tsx
+++ b/src/app/leverage/components/stats/index.tsx
@@ -45,7 +45,7 @@ export function QuickStats() {
       className='bg-ic-gray-950 flex w-full items-center justify-between rounded-lg'
       style={{ boxShadow: '2px 2px 30px 0px rgba(0, 0, 0, 0.06)' }}
     >
-      <div className='flex w-full items-center justify-between py-2 pl-6 pr-16'>
+      <div className='flex w-full items-center justify-between py-4 pl-6 pr-16'>
         <TokenSelector
           selectedToken={indexToken}
           onClick={onOpenSelectIndexToken}

--- a/src/app/leverage/components/stats/leverage-selector-container.tsx
+++ b/src/app/leverage/components/stats/leverage-selector-container.tsx
@@ -1,17 +1,124 @@
+import { Popover, PopoverButton, PopoverPanel } from '@headlessui/react'
+import { getTokenByChainAndSymbol } from '@indexcoop/tokenlists'
+import Image from 'next/image'
+import { arbitrum } from 'viem/chains'
+
+import { useLeverageToken } from '@/app/leverage/provider'
+
 import { LeverageSelector } from './leverage-selector'
 import { StatsMetric } from './stats-metric'
 
+type LeverageRatio = {
+  icon: string
+  ratio: string
+  networks: string[]
+  leverage: string
+  isPositive: boolean
+}
+
+const ratios: LeverageRatio[] = [
+  {
+    icon: getTokenByChainAndSymbol(arbitrum.id, 'ETH2X').logoURI,
+    ratio: '2x',
+    // TODO: merge other earn PR first or cherry-pick here?
+    networks: [
+      getTokenByChainAndSymbol(arbitrum.id, 'ETH2X').logoURI,
+      getTokenByChainAndSymbol(arbitrum.id, 'ETH2X').logoURI,
+      getTokenByChainAndSymbol(arbitrum.id, 'ETH2X').logoURI,
+      // '/assets/ethereum-network-logo.svg',
+      // '/assets/arbitrum-network-logo.svg',
+      // '/assets/base-network-icon.svg',
+    ],
+    leverage: '1.94x',
+    isPositive: true,
+  },
+  {
+    icon: getTokenByChainAndSymbol(arbitrum.id, 'ETH3X').logoURI,
+    ratio: '3x',
+    networks: [
+      getTokenByChainAndSymbol(arbitrum.id, 'ETH2X').logoURI,
+      getTokenByChainAndSymbol(arbitrum.id, 'ETH2X').logoURI,
+      // '/assets/ethereum-network-logo.svg',
+      // '/assets/arbitrum-network-logo.svg',
+    ],
+    leverage: '2.96x',
+    isPositive: true,
+  },
+  {
+    icon: getTokenByChainAndSymbol(arbitrum.id, 'iETH1X').logoURI,
+    ratio: '-1x',
+    networks: [
+      getTokenByChainAndSymbol(arbitrum.id, 'ETH2X').logoURI,
+      // '/assets/ethereum-network-logo.svg'
+    ],
+    leverage: '-1.10x',
+    isPositive: false,
+  },
+]
+
+function LeverageRatioItem({ item }: { item: LeverageRatio }) {
+  return (
+    <div className='border-ic-gray-600 flex items-center justify-between border-t px-4 py-3 first:border-t-0'>
+      <div className='flex items-center gap-2'>
+        <Image
+          src={item.icon}
+          alt={`${item.ratio} leverage`}
+          height={16}
+          width={16}
+        />
+        <span className='text-ic-white text-xs font-medium'>{item.ratio}</span>
+      </div>
+      <div className='flex gap-1'>
+        {item.networks.map((network, idx) => (
+          <Image
+            key={idx}
+            src={network}
+            alt={'Network Icon'}
+            height={12}
+            width={12}
+          />
+        ))}
+      </div>
+      <span className={'text-ic-white text-right text-xs font-medium'}>
+        {item.leverage}
+      </span>
+    </div>
+  )
+}
+
 export function LeverageSelectorContainer() {
-  const isFetchingStats = false
+  const { isFetchingStats } = useLeverageToken()
   return (
     <div className='border-ic-black flex h-full w-2/3 items-center gap-8 border-l px-16 py-0'>
-      <LeverageSelector
-        leverage={'2x'}
-        leverageType={'Long'}
-        onClick={() => console.log('select long')}
-      />
+      <Popover className='flex'>
+        <PopoverButton className='data-[active]:text-ic-gray-950 data-[active]:dark:text-ic-white data-[hover]:text-ic-gray-700 data-[hover]:dark:text-ic-gray-100 text-ic-gray-500 dark:text-ic-gray-300 focus:outline-none data-[focus]:outline-1'>
+          <LeverageSelector
+            leverage={'2x'}
+            leverageType={'Long'}
+            onClick={() => console.log('select long')}
+          />
+        </PopoverButton>
+        <PopoverPanel
+          transition
+          anchor='bottom'
+          className='z-10 mt-4 rounded-lg transition duration-200 ease-in-out data-[closed]:-translate-y-1 data-[closed]:opacity-0'
+        >
+          <div className='w-full max-w-xl'>
+            <div className='text-ic-gray-400 space-between flex gap-5 px-5 py-1 text-[11px]'>
+              <span>Strategy</span>
+              <span>Networks</span>
+              <span>Current Leverage</span>
+            </div>
+            <div className='w-full rounded-lg bg-[#1A2A2B]'>
+              {ratios.map((item, index) => (
+                <LeverageRatioItem item={item} key={index} />
+              ))}
+            </div>
+          </div>
+        </PopoverPanel>
+      </Popover>
       <StatsMetric
-        className='w-16'
+        className='hidden w-16 md:flex'
         isLoading={isFetchingStats}
         label='Net Rate'
         value={'0.03%'}

--- a/src/app/leverage/components/stats/stats-metric.tsx
+++ b/src/app/leverage/components/stats/stats-metric.tsx
@@ -16,11 +16,11 @@ export function StatsMetric({
   value,
 }: Props) {
   return (
-    <div className={cn('flex flex-col gap-1', className)}>
+    <div className={cn('flex-col items-center gap-1', className)}>
       <div className='text-ic-gray-300 text-xs'>{label}</div>
       <div
         className={cn(
-          'text-ic-gray-100 h-6 text-sm font-medium',
+          'text-ic-gray-100 text-sm font-medium',
           isLoading && 'bg-ic-gray-700 animate-pulse rounded-md text-opacity-0',
           overrideLabelColor,
         )}

--- a/src/app/leverage/page.tsx
+++ b/src/app/leverage/page.tsx
@@ -10,7 +10,6 @@ import TradingViewWidget from '@/app/leverage/components/trading-view-widget'
 import { useLeverageToken } from '@/app/leverage/provider'
 import { ChartTab } from '@/app/leverage/types'
 import { PriceChart } from '@/components/charts/price-chart'
-import { BTC, ETH } from '@/constants/tokens'
 
 import { FaqSection } from './components/faq-section'
 import { LeverageWidget } from './components/leverage-widget'
@@ -19,7 +18,7 @@ import { YourTokens } from './components/your-tokens'
 const surveyTracking = { utm_source: 'app' }
 
 export default function Page() {
-  const { baseToken, indexToken, nav } = useLeverageToken()
+  const { indexToken, nav } = useLeverageToken()
   const [currentTab, setCurrentTab] = useState<ChartTab>('indexcoop-chart')
   const { colorMode, toggleColorMode } = useColorMode()
 

--- a/src/app/leverage/page.tsx
+++ b/src/app/leverage/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useColorMode, useDisclosure } from '@chakra-ui/react'
+import { useColorMode } from '@chakra-ui/react'
 import { PopupButton } from '@typeform/embed-react'
 import { Suspense, useEffect, useState } from 'react'
 
@@ -10,9 +10,7 @@ import TradingViewWidget from '@/app/leverage/components/trading-view-widget'
 import { useLeverageToken } from '@/app/leverage/provider'
 import { ChartTab } from '@/app/leverage/types'
 import { PriceChart } from '@/components/charts/price-chart'
-import { SelectTokenModal } from '@/components/swap/components/select-token-modal'
 import { BTC, ETH } from '@/constants/tokens'
-import { useWallet } from '@/lib/hooks/use-wallet'
 
 import { FaqSection } from './components/faq-section'
 import { LeverageWidget } from './components/leverage-widget'
@@ -21,14 +19,7 @@ import { YourTokens } from './components/your-tokens'
 const surveyTracking = { utm_source: 'app' }
 
 export default function Page() {
-  const { address } = useWallet()
-  const {
-    isOpen: isSelectBaseTokenOpen,
-    onOpen: onOpenSelectBaseToken,
-    onClose: onCloseSelectBaseToken,
-  } = useDisclosure()
-  const { baseToken, baseTokens, indexToken, nav, onSelectBaseToken } =
-    useLeverageToken()
+  const { baseToken, indexToken, nav } = useLeverageToken()
   const [currentTab, setCurrentTab] = useState<ChartTab>('indexcoop-chart')
   const { colorMode, toggleColorMode } = useColorMode()
 
@@ -83,9 +74,7 @@ export default function Page() {
               </div>
             </div>
             <Suspense>
-              <LeverageWidget
-                onClickBaseTokenSelector={onOpenSelectBaseToken}
-              />
+              <LeverageWidget />
             </Suspense>
           </div>
           <div className='flex flex-col gap-6 lg:flex-row'>
@@ -103,18 +92,6 @@ export default function Page() {
         </div>
         <FaqSection />
       </div>
-      <SelectTokenModal
-        isDarkMode={true}
-        isOpen={isSelectBaseTokenOpen}
-        showBalances={false}
-        onClose={onCloseSelectBaseToken}
-        onSelectedToken={(tokenSymbol) => {
-          onSelectBaseToken(tokenSymbol)
-          onCloseSelectBaseToken()
-        }}
-        address={address}
-        tokens={baseTokens}
-      />
     </div>
   )
 }

--- a/src/components/selectors/buy-sell-selector-button.tsx
+++ b/src/components/selectors/buy-sell-selector-button.tsx
@@ -23,7 +23,7 @@ export function BuySellSelectorButton({
     >
       <div
         className={cn(
-          'py-5 text-center text-sm font-bold',
+          'py-4 text-center text-sm font-medium',
           isSelected
             ? 'text-ic-gray-700 dark:text-ic-white'
             : 'text-ic-gray-500',


### PR DESCRIPTION
## **Summary of Changes**

* Adds leverage ratio submenu
* Adds some styling updates for the leverage trade widget
* Fixes padding for quick stats header

Note that the assets for the networks are in https://github.com/IndexCoop/index-app/pull/1685 but we would probably not release the lev ratio submenu yet - as that whole section would be hidden (due to missing data). ⚠️ 

## **Test Data or Screenshots**

<img width="1512" alt="Bildschirmfoto 2024-12-16 um 18 37 56" src="https://github.com/user-attachments/assets/723a90ca-5d08-419f-8214-1f11647f9964" />


###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
