### PR TITLE
feat: product list digits

### DIFF
--- a/src/app/products/components/product-row-item/product-row-item-desktop.tsx
+++ b/src/app/products/components/product-row-item/product-row-item-desktop.tsx
@@ -17,7 +17,7 @@ const cellClassName = 'text-ic-gray-600 text-sm font-medium min-w-[120px]'
 export function ProductRowItemDesktop({
   isLoading,
   hideApyColumn,
-  product: { logoURI, symbol, name, tradeHref, price, delta, apy, tvl },
+  product: { logoURI, symbol, name, tradeHref, price, delta, apy, tvl, digits },
 }: ProductRowItemProps) {
   return (
     <Link
@@ -52,7 +52,7 @@ export function ProductRowItemDesktop({
         )}
       </div>
       <div className={clsx(cellClassName, '!min-w-[130px] px-2 text-right')}>
-        {isLoading ? <LoadingSkeleton /> : formatPrice(price)}
+        {isLoading ? <LoadingSkeleton /> : formatPrice(price, digits)}
       </div>
       <div
         className={clsx(cellClassName, 'px-2 text-right', {

--- a/src/app/products/components/product-row-item/product-row-item-mobile.tsx
+++ b/src/app/products/components/product-row-item/product-row-item-mobile.tsx
@@ -18,7 +18,7 @@ const rowClassName = 'text-ic-gray-600 text-sm font-medium text-right'
 export function ProductRowItemMobile({
   isLoading,
   hideApyColumn,
-  product: { logoURI, symbol, name, price, delta, apy, tradeHref, tvl },
+  product: { logoURI, symbol, name, price, delta, apy, tradeHref, tvl, digits },
 }: ProductRowItemProps) {
   return (
     <div className='flex flex-col items-center justify-between px-4 py-6 md:hidden'>
@@ -33,7 +33,7 @@ export function ProductRowItemMobile({
       </div>
       <MobileRow label='Current Price'>
         <div className={rowClassName}>
-          {isLoading ? <LoadingSkeleton /> : formatPrice(price)}
+          {isLoading ? <LoadingSkeleton /> : formatPrice(price, digits)}
         </div>
       </MobileRow>
       <MobileRow label='24h'>

--- a/src/app/products/constants/tokens.ts
+++ b/src/app/products/constants/tokens.ts
@@ -86,6 +86,7 @@ export const productTokens: ProductRow[] = [
     hasApy: true,
     listType: 'Earn',
     tradeHref: buildEarnTradePath('icUSD', 'USDC', base.id),
+    digits: 4,
   },
   {
     ...getTokenByChainAndSymbol(mainnet.id, 'cdETI'),

--- a/src/app/products/types/product.ts
+++ b/src/app/products/types/product.ts
@@ -12,4 +12,5 @@ export type ProductRow = {
   delta?: number
   apy?: number | null
   tvl?: number
+  digits?: number
 }

--- a/src/app/products/utils/formatters.ts
+++ b/src/app/products/utils/formatters.ts
@@ -20,14 +20,17 @@ export function formatPercentage(
   return `${percentage.toFixed(2)}%`
 }
 
-export function formatPrice(price?: number | bigint | null) {
+export function formatPrice(
+  price?: number | bigint | null,
+  digits: number = 2,
+) {
   if (price === undefined || price === null) return ''
 
   return Intl.NumberFormat('en', {
     style: 'currency',
     currency: 'USD',
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
   })
     .format(price)
     .toString()


### PR DESCRIPTION
## **Summary of Changes**

Add support to specify digits on the tokens listed on the product page.

## **Test Data or Screenshots**

<img width="539" alt="image" src="https://github.com/user-attachments/assets/c8c030a8-24eb-45aa-b580-d3b97dc0d510" />

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
