### PR TITLE
fix: add body white fallback

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ type LayoutProps = {
 export default function RootLayout({ children }: LayoutProps) {
   return (
     <html lang='en'>
-      <body className='dark:bg-ic-black'>
+      <body className='bg-ic-white dark:bg-ic-black'>
         {children}
         <SafaryScript />
         <MavaScript />


### PR DESCRIPTION
## **Summary of Changes**

Forces white background on `body` to override Chakra.

## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
