### PR TITLE
Chore: Avg Entry Price Formula update

### DIFF
--- a/src/app/api/leverage/history/route.ts
+++ b/src/app/api/leverage/history/route.ts
@@ -66,8 +66,8 @@ const calculateAverageEntryPrice = (
 
         acc[tokenAddress].sum +=
           (position.trade.underlyingAssetUnitPrice ?? 0) *
-          (position.metrics.endingUnits ?? 0)
-        acc[tokenAddress].count += position.metrics.endingUnits ?? 0
+          (position.metrics.totalPurchaseSize ?? 0)
+        acc[tokenAddress].count += position.metrics.totalPurchaseSize ?? 0
       }
       return acc
     },


### PR DESCRIPTION
changed to weighted average of totalPurchaseSize * underlyingAssetPrice

## **Summary of Changes**

## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
