### PR TITLE
feat: add eth max balance

### DIFF
--- a/src/app/earn/components/earn-widget/index.tsx
+++ b/src/app/earn/components/earn-widget/index.tsx
@@ -17,10 +17,12 @@ import { WarningType } from '@/components/swap/components/warning'
 import { TradeButtonState } from '@/components/swap/hooks/use-trade-button-state'
 import { TokenDisplay } from '@/components/token-display'
 import { useDisclosure } from '@/lib/hooks/use-disclosure'
+import { useGasData } from '@/lib/hooks/use-gas-data'
 import { useSupportedNetworks } from '@/lib/hooks/use-network'
 import { useWallet } from '@/lib/hooks/use-wallet'
 import { useSlippage } from '@/lib/providers/slippage'
 import { formatWei } from '@/lib/utils'
+import { getMaxBalance } from '@/lib/utils/max-balance'
 
 import { useFormattedEarnData } from '../../use-formatted-data'
 
@@ -29,6 +31,7 @@ import './styles.css'
 const hiddenLeverageWarnings = [WarningType.flashbots]
 
 export function EarnWidget() {
+  const gasData = useGasData()
   const isSupportedNetwork = useSupportedNetworks(supportedNetworks)
   const { queryParams } = useQueryParams()
   const { address } = useWallet()
@@ -86,8 +89,9 @@ export function EarnWidget() {
 
   const onClickBalance = useCallback(() => {
     if (!inputBalance) return
-    onChangeInputTokenAmount(formatWei(inputBalance, inputToken.decimals))
-  }, [inputBalance, inputToken, onChangeInputTokenAmount])
+    const maxBalance = getMaxBalance(inputToken, inputBalance, gasData)
+    onChangeInputTokenAmount(formatWei(maxBalance, inputToken.decimals))
+  }, [gasData, inputBalance, inputToken, onChangeInputTokenAmount])
 
   useEffect(() => {
     setSlippageForToken(isMinting ? outputToken.symbol : inputToken.symbol)

--- a/src/app/leverage/components/leverage-widget/index.tsx
+++ b/src/app/leverage/components/leverage-widget/index.tsx
@@ -13,11 +13,13 @@ import { TransactionReviewModal } from '@/components/swap/components/transaction
 import { WarningType } from '@/components/swap/components/warning'
 import { TradeButtonState } from '@/components/swap/hooks/use-trade-button-state'
 import { useDisclosure } from '@/lib/hooks/use-disclosure'
+import { useGasData } from '@/lib/hooks/use-gas-data'
 import { useSupportedNetworks } from '@/lib/hooks/use-network'
 import { useQueryParams } from '@/lib/hooks/use-query-params'
 import { useWallet } from '@/lib/hooks/use-wallet'
 import { useSlippage } from '@/lib/providers/slippage'
 import { formatWei } from '@/lib/utils'
+import { getMaxBalance } from '@/lib/utils/max-balance'
 
 import { useFormattedLeverageData } from '../../use-formatted-data'
 
@@ -30,6 +32,7 @@ import './styles.css'
 const hiddenLeverageWarnings = [WarningType.flashbots]
 
 export function LeverageWidget() {
+  const gasData = useGasData()
   const isSupportedNetwork = useSupportedNetworks(supportedNetworks)
   const { queryParams } = useQueryParams()
   const { address } = useWallet()
@@ -89,8 +92,9 @@ export function LeverageWidget() {
 
   const onClickBalance = useCallback(() => {
     if (!inputBalance) return
-    onChangeInputTokenAmount(formatWei(inputBalance, inputToken.decimals))
-  }, [inputBalance, inputToken, onChangeInputTokenAmount])
+    const maxBalance = getMaxBalance(inputToken, inputBalance, gasData)
+    onChangeInputTokenAmount(formatWei(maxBalance, inputToken.decimals))
+  }, [gasData, inputBalance, inputToken, onChangeInputTokenAmount])
 
   return (
     <div

--- a/src/lib/hooks/use-gas-data.ts
+++ b/src/lib/hooks/use-gas-data.ts
@@ -43,8 +43,6 @@ export function useGasData(): GasData {
         rewardPercentiles: [50],
       })
 
-      console.log(feeHistory)
-
       let baseFeePerGas = baseFeePerGasFallback
       let maxPriorityFeePerGas = maxPriorityFeePerGasFallback
 

--- a/src/lib/hooks/use-gas-data.ts
+++ b/src/lib/hooks/use-gas-data.ts
@@ -10,9 +10,9 @@ export interface GasData {
 }
 
 // Base fee: 15 GWei (fallback)
-let baseFeePerGasFallback = BigInt(15e9)
+const baseFeePerGasFallback = BigInt(15e9)
 // Max Priority Fee (tip): 2 GWei (fallback)
-let maxPriorityFeePerGasFallback = BigInt(2e9)
+const maxPriorityFeePerGasFallback = BigInt(2e9)
 
 const fallbackData: GasData = {
   baseFeePerGas: baseFeePerGasFallback,

--- a/src/lib/hooks/use-gas-data.ts
+++ b/src/lib/hooks/use-gas-data.ts
@@ -1,0 +1,65 @@
+import { useQuery } from '@tanstack/react-query'
+import { usePublicClient } from 'wagmi'
+
+import { useNetwork } from '@/lib/hooks/use-network'
+
+// Base fee: 15 GWei (fallback)
+let baseFeePerGasFallback = BigInt(15e9)
+// Max Priority Fee (tip): 2 GWei (fallback)
+let maxPriorityFeePerGasFallback = BigInt(2e9)
+
+export function useGasData() {
+  const { chainId } = useNetwork()
+  const publicClient = usePublicClient()
+
+  const { data } = useQuery({
+    enabled: Boolean(chainId),
+    initialData: {
+      baseFeePerGas: baseFeePerGasFallback,
+      maxFeePerGas: baseFeePerGasFallback + maxPriorityFeePerGasFallback,
+      maxPriorityFeePerGas: maxPriorityFeePerGasFallback,
+    },
+    queryKey: [
+      'use-gas-data',
+      {
+        chainId,
+        publicClient,
+      },
+    ],
+    queryFn: async () => {
+      if (!chainId) return null
+      if (!publicClient) return null
+
+      const feeHistory = await publicClient.getFeeHistory({
+        blockCount: 10,
+        rewardPercentiles: [50],
+      })
+
+      console.log(feeHistory)
+
+      let baseFeePerGas = baseFeePerGasFallback
+      let maxPriorityFeePerGas = maxPriorityFeePerGasFallback
+
+      if (feeHistory && feeHistory.reward) {
+        baseFeePerGas =
+          feeHistory.baseFeePerGas.sort()[
+            Math.floor(feeHistory.baseFeePerGas.length / 2)
+          ]
+        // Get median of maxPriorityFeePerGas
+        const priorityFees = feeHistory.reward.map((reward) => reward[0])
+        maxPriorityFeePerGas =
+          priorityFees.sort()[Math.floor(priorityFees.length / 2)]
+      }
+
+      const maxFeePerGas = baseFeePerGas + maxPriorityFeePerGas
+
+      return {
+        baseFeePerGas,
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+      }
+    },
+  })
+
+  return data
+}

--- a/src/lib/hooks/use-gas-data.ts
+++ b/src/lib/hooks/use-gas-data.ts
@@ -49,6 +49,7 @@ export function useGasData(): GasData {
       let maxPriorityFeePerGas = maxPriorityFeePerGasFallback
 
       if (feeHistory && feeHistory.reward) {
+        // Get median of baseFeePerGas
         baseFeePerGas =
           feeHistory.baseFeePerGas.sort()[
             Math.floor(feeHistory.baseFeePerGas.length / 2)

--- a/src/lib/hooks/use-gas-data.ts
+++ b/src/lib/hooks/use-gas-data.ts
@@ -8,17 +8,19 @@ let baseFeePerGasFallback = BigInt(15e9)
 // Max Priority Fee (tip): 2 GWei (fallback)
 let maxPriorityFeePerGasFallback = BigInt(2e9)
 
+const fallbackData = {
+  baseFeePerGas: baseFeePerGasFallback,
+  maxFeePerGas: baseFeePerGasFallback + maxPriorityFeePerGasFallback,
+  maxPriorityFeePerGas: maxPriorityFeePerGasFallback,
+}
+
 export function useGasData() {
   const { chainId } = useNetwork()
   const publicClient = usePublicClient()
 
   const { data } = useQuery({
     enabled: Boolean(chainId),
-    initialData: {
-      baseFeePerGas: baseFeePerGasFallback,
-      maxFeePerGas: baseFeePerGasFallback + maxPriorityFeePerGasFallback,
-      maxPriorityFeePerGas: maxPriorityFeePerGasFallback,
-    },
+    initialData: fallbackData,
     queryKey: [
       'use-gas-data',
       {
@@ -27,7 +29,7 @@ export function useGasData() {
       },
     ],
     queryFn: async () => {
-      if (!chainId) return null
+      if (!chainId) return fallbackData
       if (!publicClient) return null
 
       const feeHistory = await publicClient.getFeeHistory({

--- a/src/lib/hooks/use-gas-data.ts
+++ b/src/lib/hooks/use-gas-data.ts
@@ -3,18 +3,24 @@ import { usePublicClient } from 'wagmi'
 
 import { useNetwork } from '@/lib/hooks/use-network'
 
+export interface GasData {
+  baseFeePerGas: bigint
+  maxFeePerGas: bigint
+  maxPriorityFeePerGas: bigint
+}
+
 // Base fee: 15 GWei (fallback)
 let baseFeePerGasFallback = BigInt(15e9)
 // Max Priority Fee (tip): 2 GWei (fallback)
 let maxPriorityFeePerGasFallback = BigInt(2e9)
 
-const fallbackData = {
+const fallbackData: GasData = {
   baseFeePerGas: baseFeePerGasFallback,
   maxFeePerGas: baseFeePerGasFallback + maxPriorityFeePerGasFallback,
   maxPriorityFeePerGas: maxPriorityFeePerGasFallback,
 }
 
-export function useGasData() {
+export function useGasData(): GasData {
   const { chainId } = useNetwork()
   const publicClient = usePublicClient()
 
@@ -30,7 +36,7 @@ export function useGasData() {
     ],
     queryFn: async () => {
       if (!chainId) return fallbackData
-      if (!publicClient) return null
+      if (!publicClient) return fallbackData
 
       const feeHistory = await publicClient.getFeeHistory({
         blockCount: 10,

--- a/src/lib/utils/max-balance.ts
+++ b/src/lib/utils/max-balance.ts
@@ -6,11 +6,10 @@ export function getMaxBalance(
   inputBalance: bigint,
   gasData: GasData,
 ): bigint {
-  console.log(inputToken.symbol, inputToken.address, 'max')
   if (inputToken.symbol === 'ETH') {
     const gasLimit = BigInt(1_500_000)
     const gasCosts = gasLimit * gasData.maxFeePerGas
-    const maxEthBalance = inputBalance - gasCosts * BigInt(2)
+    const maxEthBalance = inputBalance - gasCosts * BigInt(5)
     return maxEthBalance
   }
   // If no ETH, we can always just use the full balance

--- a/src/lib/utils/max-balance.ts
+++ b/src/lib/utils/max-balance.ts
@@ -1,0 +1,19 @@
+import { Token } from '@/constants/tokens'
+import { GasData } from '@/lib/hooks/use-gas-data'
+
+export function getMaxBalance(
+  inputToken: Token,
+  inputBalance: bigint,
+  gasData: GasData,
+): bigint {
+  console.log(inputToken.symbol, inputToken.address, 'max')
+  if (inputToken.symbol === 'ETH') {
+    // TODO: individual gas limits based on index token?
+    const gasLimit = BigInt(1_500_000)
+    const gasCosts = gasLimit * gasData.maxFeePerGas
+    const maxEthBalance = inputBalance - gasCosts
+    return maxEthBalance
+  }
+  // If no ETH, we can always just use the full balance
+  return inputBalance
+}

--- a/src/lib/utils/max-balance.ts
+++ b/src/lib/utils/max-balance.ts
@@ -8,10 +8,9 @@ export function getMaxBalance(
 ): bigint {
   console.log(inputToken.symbol, inputToken.address, 'max')
   if (inputToken.symbol === 'ETH') {
-    // TODO: individual gas limits based on index token?
     const gasLimit = BigInt(1_500_000)
     const gasCosts = gasLimit * gasData.maxFeePerGas
-    const maxEthBalance = inputBalance - gasCosts
+    const maxEthBalance = inputBalance - gasCosts * BigInt(2)
     return maxEthBalance
   }
   // If no ETH, we can always just use the full balance


### PR DESCRIPTION
## **Summary of Changes**

Adds max ETH balance. Requires to substract the approximate gas costs.

### Formula

```
const gasCosts = gasLimit * (baseFee + maxPriorityFee)
const maxEthBalance = inputBalance - gasCosts 
```

_\* base and max priority fee are medians of the last 10 blocks fetched from the network's fee history._


## Resources

* https://ethereum.org/en/developers/docs/gas/
* https://www.blocknative.com/gas-estimator

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
