### PR TITLE
fix: allowed github images path

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -45,6 +45,7 @@ const nextConfig = {
       {
         protocol: 'https',
         hostname: 'raw.githubusercontent.com',
+        pathname: '/trustwallet/assets/master/blockchains/ethereum/assets/**',
       },
     ],
   },


### PR DESCRIPTION
## **Summary of Changes**

Hardens assets that could be loaded from github. Right now this should only be assets from the trust wallet repo e.g. https://github.com/IndexCoop/tokenlists/blob/fefcf619da04146968d33a6cae4ebe417b3d944d/src/tokenlist.json.ts#L1920

## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
