### PR TITLE
fix: mobile tradingview chart

### DIFF
--- a/src/app/leverage/components/trading-view-chart-container.tsx
+++ b/src/app/leverage/components/trading-view-chart-container.tsx
@@ -32,6 +32,7 @@ export const TradingViewChartContainer = () => {
         'header_saveload',
         'header_symbol_search',
       ],
+      enabled_features: ['iframe_loading_compatibility_mode'],
       client_id: 'indexcoop',
       fullscreen: false,
       autosize: true,

--- a/src/app/leverage/components/trading-view-chart.tsx
+++ b/src/app/leverage/components/trading-view-chart.tsx
@@ -10,7 +10,6 @@ export function TradingViewChart() {
   const [isScriptReady, setIsScriptReady] = useState(false)
   const { isConnected } = useWallet()
   const { open } = useAppKit()
-  console.log('isConnected', isConnected)
   return (
     <div className='xs:h-[422px] relative aspect-square w-full lg:aspect-auto'>
       <Script
@@ -19,7 +18,7 @@ export function TradingViewChart() {
           setIsScriptReady(true)
         }}
       />
-      {isScriptReady ? (
+      {isScriptReady && isConnected ? (
         <TradingViewChartContainer />
       ) : (
         <div className='bg-ic-black/95 absolute inset-0 z-20 flex items-center justify-center'>

--- a/src/app/leverage/components/trading-view-chart.tsx
+++ b/src/app/leverage/components/trading-view-chart.tsx
@@ -10,6 +10,7 @@ export function TradingViewChart() {
   const [isScriptReady, setIsScriptReady] = useState(false)
   const { isConnected } = useWallet()
   const { open } = useAppKit()
+  console.log('isConnected', isConnected)
   return (
     <div className='xs:h-[422px] relative aspect-square w-full lg:aspect-auto'>
       <Script
@@ -18,7 +19,7 @@ export function TradingViewChart() {
           setIsScriptReady(true)
         }}
       />
-      {isScriptReady && isConnected ? (
+      {isScriptReady ? (
         <TradingViewChartContainer />
       ) : (
         <div className='bg-ic-black/95 absolute inset-0 z-20 flex items-center justify-center'>


### PR DESCRIPTION
Fixes an issue where the chart doesn't load on mobile, uses the `iframe_loading_compatibility_mode` setting. https://www.tradingview.com/charting-library-docs/latest/customization/Featuresets/#iframe_loading_compatibility_mode