### PR TITLE
chore: move cdETI to legacy

### DIFF
--- a/src/app/legacy/config/index.ts
+++ b/src/app/legacy/config/index.ts
@@ -4,8 +4,6 @@ import {
   IndexDebtIssuanceModuleV2Address_v2,
 } from '@indexcoop/flash-mint-sdk'
 
-import { LegacyToken } from '@/app/legacy/types'
-
 import {
   BedIndex,
   Bitcoin2xFlexibleLeverageIndex,
@@ -14,6 +12,7 @@ import {
   GMI,
   GitcoinStakedETHIndex,
   LeveragedRethStakingYield,
+  cdETI,
   dsETH,
   ic21,
 } from './tokens/mainnet'
@@ -26,6 +25,8 @@ import {
   Matic2xFlexibleLeverageIndexPolygon,
 } from './tokens/polygon'
 
+import type { LegacyToken } from '@/app/legacy/types'
+
 const DebtIssuanceModuleAddress = '0x39F024d621367C044BacE2bf0Fb15Fb3612eCB92'
 const DebtIssuanceModuleV2PolygonAddress =
   '0xf2dC2f456b98Af9A6bEEa072AF152a7b0EaA40C9'
@@ -35,6 +36,7 @@ export const Issuance: { [key: string]: string } = {
   [Bitcoin2xFlexibleLeverageIndex.symbol]: DebtIssuanceModuleV2Address,
   [Bitcoin2xFlexibleLeverageIndexPolygon.symbol]:
     DebtIssuanceModuleV2PolygonAddress,
+  [cdETI.symbol]: IndexDebtIssuanceModuleV2Address_v2,
   [DATA.symbol]: DebtIssuanceModuleAddress,
   [dsETH.symbol]: IndexDebtIssuanceModuleV2Address_v2,
   [Ethereum2xFlexibleLeverageIndex.symbol]: DebtIssuanceModuleV2Address,
@@ -63,6 +65,7 @@ export const LegacyTokenList: LegacyToken[] = [
     ...Ethereum2xFlexibleLeverageIndex,
     image: Ethereum2xFlexibleLeverageIndex.logoURI,
   },
+  { ...cdETI, image: cdETI.logoURI },
   { ...dsETH, image: dsETH.logoURI },
   { ...ic21, image: ic21.logoURI },
   { ...GitcoinStakedETHIndex, image: GitcoinStakedETHIndex.logoURI },

--- a/src/app/legacy/config/tokens/mainnet.ts
+++ b/src/app/legacy/config/tokens/mainnet.ts
@@ -5,6 +5,7 @@ export const Bitcoin2xFlexibleLeverageIndex = getTokenByChainAndSymbol(
   1,
   'BTC2x-FLI',
 )
+export const cdETI = getTokenByChainAndSymbol(1, 'cdETI')
 export const DATA = getTokenByChainAndSymbol(1, 'DATA')
 export const dsETH = getTokenByChainAndSymbol(1, 'dsETH')
 export const Ethereum2xFlexibleLeverageIndex = getTokenByChainAndSymbol(

--- a/src/app/products/constants/tokens.ts
+++ b/src/app/products/constants/tokens.ts
@@ -1,13 +1,14 @@
 import { getTokenByChainAndSymbol } from '@indexcoop/tokenlists'
 import { arbitrum, mainnet } from 'viem/chains'
 
-import { ProductRow } from '@/app/products/types/product'
 import {
   buildEarnTradePath,
   buildLegacyPath,
   buildLeverageTradePath,
   buildSwapTradePath,
 } from '@/app/products/utils/trade-path'
+
+import type { ProductRow } from '@/app/products/types/product'
 
 export const productTokens: ProductRow[] = [
   {
@@ -75,12 +76,6 @@ export const productTokens: ProductRow[] = [
     hasApy: false,
     listType: 'Strategies',
     tradeHref: buildLegacyPath(),
-  },
-  {
-    ...getTokenByChainAndSymbol(mainnet.id, 'cdETI'),
-    hasApy: false,
-    listType: 'Strategies',
-    tradeHref: buildSwapTradePath('cdeti'),
   },
   {
     ...getTokenByChainAndSymbol(arbitrum.id, 'ETH2xBTC'),

--- a/src/constants/slippage.ts
+++ b/src/constants/slippage.ts
@@ -1,10 +1,9 @@
-import { CoinDeskEthTrendIndex, HighYieldETHIndex, icETHIndex } from './tokens'
+import { HighYieldETHIndex, icETHIndex } from './tokens'
 
 // Slippage default hard coded to 0.5%
 export const slippageDefault = 0.5
 
 export const slippageMap = new Map([
-  [CoinDeskEthTrendIndex.symbol, 0.5],
   [HighYieldETHIndex.symbol, 0.05],
   [icETHIndex.symbol, 0.5],
 ])

--- a/src/constants/tokenlists.ts
+++ b/src/constants/tokenlists.ts
@@ -2,7 +2,6 @@ import { getTokenByChainAndSymbol } from '@indexcoop/tokenlists'
 import { arbitrum, base } from 'viem/chains'
 
 import {
-  CoinDeskEthTrendIndex,
   DAI,
   DefiPulseIndex,
   ETH,
@@ -13,7 +12,7 @@ import {
   RETH,
   SETH2,
   STETH,
-  Token,
+  type Token,
   USDC,
   USDT,
   WBTC,
@@ -53,7 +52,6 @@ export const indicesTokenList = [
   IndexToken,
   DefiPulseIndex,
   MetaverseIndex,
-  CoinDeskEthTrendIndex,
   HighYieldETHIndex,
   { ...icUSD, image: icUSD.logoURI },
 ] as Token[]

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -16,15 +16,6 @@ export interface Token {
  * Indices
  */
 
-export const CoinDeskEthTrendIndex: Token = {
-  name: 'CoinDesk ETH Trend Index',
-  symbol: 'cdETI',
-  image:
-    'https://uploads-ssl.webflow.com/62e3ff7a08cb1968bf057388/651f04818f458f918171c84d_cdETI-logo.svg',
-  address: '0x55b2CFcfe99110C773f00b023560DD9ef6C8A13B',
-  decimals: 18,
-}
-
 export const DefiPulseIndex: Token = {
   name: 'DeFi Pulse Index',
   symbol: 'DPI',

--- a/src/lib/hooks/use-best-quote/index.ts
+++ b/src/lib/hooks/use-best-quote/index.ts
@@ -2,10 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { usePublicClient } from 'wagmi'
 
 import { ARBITRUM } from '@/constants/chains'
-import {
-  isAvailableForFlashMint,
-  isAvailableForSwap,
-} from '@/lib/hooks/use-best-quote/utils/available'
+import { isAvailableForFlashMint } from '@/lib/hooks/use-best-quote/utils/available'
 import { useNetwork } from '@/lib/hooks/use-network'
 import { useWallet } from '@/lib/hooks/use-wallet'
 import { parseUnits } from '@/lib/utils'
@@ -102,7 +99,7 @@ export const useBestQuote = (
       const outputTokenPrice = await getTokenPrice(outputToken, 1)
 
       const canFlashmintIndexToken = isAvailableForFlashMint(indexToken)
-      const canSwapIndexToken = isAvailableForSwap(indexToken)
+      const canSwapIndexToken = true
 
       const fetchFlashMintQuote = async () => {
         if (canFlashmintIndexToken) {
@@ -184,7 +181,7 @@ export const useBestQuote = (
       quoteFlashMint?.outputTokenAmountUsdAfterFees ?? null,
     )
     const canFlashmintIndexToken = isAvailableForFlashMint(indexToken)
-    const canSwapIndexToken = isAvailableForSwap(indexToken)
+    const canSwapIndexToken = true
     const results = {
       bestQuote,
       results: {

--- a/src/lib/hooks/use-best-quote/utils/available.test.ts
+++ b/src/lib/hooks/use-best-quote/utils/available.test.ts
@@ -1,31 +1,10 @@
-import {
-  CoinDeskEthTrendIndex,
-  DefiPulseIndex,
-  IndexToken,
-} from '@/constants/tokens'
+import { IndexToken } from '@/constants/tokens'
 
-import { isAvailableForFlashMint, isAvailableForSwap } from './available'
+import { isAvailableForFlashMint } from './available'
 
 describe('isAvailableForFlashMint()', () => {
-  test('returns true by default', async () => {
-    const isAvailable = isAvailableForFlashMint(CoinDeskEthTrendIndex)
-    expect(isAvailable).toBe(true)
-  })
-
   test('should return false for INDEX swap availability', async () => {
     const isAvailable = isAvailableForFlashMint(IndexToken)
-    expect(isAvailable).toBe(false)
-  })
-})
-
-describe('isAvailableForSwap()', () => {
-  test('returns true by default', async () => {
-    const isAvailable = isAvailableForFlashMint(DefiPulseIndex)
-    expect(isAvailable).toBe(true)
-  })
-
-  test('should return false for cdETI swap availability', async () => {
-    const isAvailable = isAvailableForSwap(CoinDeskEthTrendIndex)
     expect(isAvailable).toBe(false)
   })
 })

--- a/src/lib/hooks/use-best-quote/utils/available.ts
+++ b/src/lib/hooks/use-best-quote/utils/available.ts
@@ -1,21 +1,8 @@
-import {
-  CoinDeskEthTrendIndex,
-  IndexToken,
-  type Token,
-} from '@/constants/tokens'
+import { IndexToken, type Token } from '@/constants/tokens'
 
 export function isAvailableForFlashMint(token: Token): boolean {
   switch (token.symbol) {
     case IndexToken.symbol:
-      return false
-    default:
-      return true
-  }
-}
-
-export function isAvailableForSwap(token: Token): boolean {
-  switch (token.symbol) {
-    case CoinDeskEthTrendIndex.symbol:
       return false
     default:
       return true

--- a/src/lib/utils/gas-defaults.ts
+++ b/src/lib/utils/gas-defaults.ts
@@ -1,5 +1,4 @@
 import {
-  CoinDeskEthTrendIndex,
   DefiPulseIndex,
   HighYieldETHIndex,
   MetaverseIndex,
@@ -9,8 +8,6 @@ import {
 export function getFlashMintGasDefault(symbol: string) {
   // INDEX are not available for flash mint
   switch (symbol) {
-    case CoinDeskEthTrendIndex.symbol:
-      return 500_000
     case DefiPulseIndex.symbol:
       return 2_000_000
     case HighYieldETHIndex.symbol:

--- a/src/lib/utils/slippage.test.ts
+++ b/src/lib/utils/slippage.test.ts
@@ -1,9 +1,5 @@
 import { slippageMap } from '@/constants/slippage'
-import {
-  CoinDeskEthTrendIndex,
-  HighYieldETHIndex,
-  icETHIndex,
-} from '@/constants/tokens'
+import { HighYieldETHIndex, icETHIndex } from '@/constants/tokens'
 
 import { getSlippageOverrideOrNull, selectSlippage } from './slippage'
 
@@ -12,12 +8,6 @@ describe('getSlippageOverrideOrNull()', () => {
     const symbol = 'MVI'
     const slippageOverride = getSlippageOverrideOrNull(symbol)
     expect(slippageOverride).toBe(null)
-  })
-
-  it('returns correct slippage for cdETI', () => {
-    const symbol = CoinDeskEthTrendIndex.symbol
-    const slippageOverride = getSlippageOverrideOrNull(symbol)
-    expect(slippageOverride).toBe(0.5)
   })
 
   it('returns correct slippage for icETH', () => {

--- a/src/lib/utils/tokens.test.ts
+++ b/src/lib/utils/tokens.test.ts
@@ -1,13 +1,9 @@
 import { currencies } from '@/constants/tokenlists'
 import {
-  CoinDeskEthTrendIndex,
-  DAI,
   DefiPulseIndex,
   ETH,
-  GUSD,
   MATIC,
   STETH,
-  USDC,
   WETH,
   icETHIndex,
 } from '@/constants/tokens'
@@ -63,14 +59,6 @@ describe('getCurrencyTokensForIndex()', () => {
     const currencyTokens = getCurrencyTokensForIndex(token, chainId)
     expect(currencyTokens.length).toEqual(defaultTokens.length)
     expect(currencyTokens).toEqual(defaultTokens)
-  })
-
-  test('returns correct tokens for cdETI', async () => {
-    const chainId = 1
-    const token = CoinDeskEthTrendIndex
-    const currencyTokens = getCurrencyTokensForIndex(token, chainId)
-    expect(currencyTokens.length).toEqual(5)
-    expect(currencyTokens).toEqual([ETH, WETH, USDC, DAI, GUSD])
   })
 
   test('returns correct currency tokens for icETH', async () => {

--- a/src/lib/utils/tokens.ts
+++ b/src/lib/utils/tokens.ts
@@ -1,5 +1,4 @@
 import { getTokenByChainAndSymbol, isAddressEqual } from '@indexcoop/tokenlists'
-import { Address } from 'viem'
 import { base } from 'viem/chains'
 
 import { ARBITRUM, BASE, MAINNET, OPTIMISM, POLYGON } from '@/constants/chains'
@@ -10,19 +9,18 @@ import {
   indicesTokenListBase,
 } from '@/constants/tokenlists'
 import {
-  CoinDeskEthTrendIndex,
-  DAI,
   ETH,
-  GUSD,
   MATIC,
   STETH,
-  Token,
+  type Token,
   USDC,
   USDT,
   WBTC,
   WETH,
   icETHIndex,
 } from '@/constants/tokens'
+
+import type { Address } from 'viem'
 
 const cbBTC = getTokenByChainAndSymbol(base.id, 'cbBTC')
 
@@ -64,14 +62,12 @@ export function getCurrencyTokensForIndex(
   if (chainId === BASE.chainId) {
     return [ETH, WETH, USDC, { ...cbBTC, image: cbBTC.logoURI }]
   }
-  if (index.symbol === CoinDeskEthTrendIndex.symbol)
-    return [ETH, WETH, USDC, DAI, GUSD]
   if (index.symbol === icETHIndex.symbol) return [ETH, WETH, STETH]
   const currencyTokens = getCurrencyTokens(chainId)
   return currencyTokens
 }
 
-export function getDefaultIndex(chainId: number = 1): Token {
+export function getDefaultIndex(chainId = 1): Token {
   if (chainId === ARBITRUM.chainId) return indicesTokenListArbitrum[0]
   if (chainId === BASE.chainId) return indicesTokenListBase[0]
   return indicesTokenList[0]


### PR DESCRIPTION
## **Summary of Changes**

Moves `cdETI` to legacy. Removes unnecessary references.

## **Test Data or Screenshots**

Did a test [transaction](https://etherscan.io/tx/0x53cf2f9c6d0b221073cf86edda518e016b7697521e0bbe8941c624ae5de8ea1e).

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
