### PR TITLE
FIX: TradingView chart script detection after page refresh

### DIFF
--- a/src/app/leverage/components/trading-view-chart.tsx
+++ b/src/app/leverage/components/trading-view-chart.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@headlessui/react'
 import { useAppKit } from '@reown/appkit/react'
 import Script from 'next/script'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { TradingViewChartContainer } from '@/app/leverage/components/trading-view-chart-container'
 import { useWallet } from '@/lib/hooks/use-wallet'
@@ -10,6 +10,17 @@ export function TradingViewChart() {
   const [isScriptReady, setIsScriptReady] = useState(false)
   const { isConnected } = useWallet()
   const { open } = useAppKit()
+
+  useEffect(() => {
+    const scriptAlreadyLoaded = document.querySelector(
+      'script[src="/tradingview-chart/datafeeds/udf/dist/bundle.js"]',
+    )
+
+    if (scriptAlreadyLoaded) {
+      setIsScriptReady(true)
+    }
+  }, [])
+
   return (
     <div className='xs:h-[422px] relative aspect-square w-full lg:aspect-auto'>
       <Script


### PR DESCRIPTION
## **Summary of Changes**

Added an effect to see if the script already in the dom. We got the disconnected state because the script was already there, and the onLoad function didnt run in that case.

## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
