### PR TITLE
use appkit account

### DIFF
--- a/src/lib/hooks/use-wallet.ts
+++ b/src/lib/hooks/use-wallet.ts
@@ -1,4 +1,5 @@
-import { useAccount, usePublicClient } from 'wagmi'
+import { useAppKitAccount } from '@reown/appkit/react'
+import { usePublicClient } from 'wagmi'
 
 import { useNetwork } from '@/lib/hooks/use-network'
 
@@ -16,7 +17,7 @@ type Account = {
 
 // A wrapper to be able to easily exchange how we retrieve the account
 export const useWallet = (): Account => {
-  const { address } = useAccount()
+  const { address } = useAppKitAccount()
   const { chainId } = useNetwork()
   const publicClient = usePublicClient({ chainId })
   const isConnected = !!address


### PR DESCRIPTION
## **Summary of Changes**

Use appkit's function to fetch address instead of wagmi. Previously, the wagmi function seemed to cause issues here when reading safe balances.

https://docs.reown.com/appkit/react/core/hooks#useappkitaccount

## **Test Data or Screenshots**

<img width="1259" alt="Bildschirmfoto 2025-04-07 um 14 56 57" src="https://github.com/user-attachments/assets/32813b68-5df6-4811-bf0e-f1851c9ffdc5" />


###### _By submitting this pull request, you are confirming the following to be true:_

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
