### PR TITLE
chore: use slippage default temporarily

### DIFF
--- a/src/lib/providers/slippage/index.tsx
+++ b/src/lib/providers/slippage/index.tsx
@@ -63,18 +63,18 @@ export const SlippageProvider = (props: { children: any }) => {
       isAuto,
     queryKey: ['auto-slippage', selectedProduct?.address, isAuto],
     queryFn: async () => {
-      const res = await fetch(
-        `/api/slippage/${selectedProduct?.chainId}/${selectedProduct?.address}`,
-      )
-      const json = await res.json()
-      let slippage = json?.slippage as number
-      if (slippage) {
-        slippage = Math.round(slippage * 10) / 10
-      } else {
-        slippage = slippageDefault
-      }
-      setAutoSlippage(slippage)
-      return slippage
+      // const res = await fetch(
+      //   `/api/slippage/${selectedProduct?.chainId}/${selectedProduct?.address}`,
+      // )
+      // const json = await res.json()
+      // let slippage = json?.slippage as number
+      // if (slippage) {
+      //   slippage = Math.round(slippage * 10) / 10
+      // } else {
+      //   slippage = slippageDefault
+      // }
+      setAutoSlippage(slippageDefault)
+      return slippageDefault
     },
   })
 


### PR DESCRIPTION
## **Summary of Changes**

Revert to using default slippage value for now (until auto slippage endpoint is tested further)

- I have reviewed the [Contribution Guidelines](https://github.com/IndexCoop/index-app/blob/master/CONTRIBUTING.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the master at `IndexCoop/index-app`.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
